### PR TITLE
feat: use bokeh to load all the static graphs from geetools 

### DIFF
--- a/docs/usage/plot/index.rst
+++ b/docs/usage/plot/index.rst
@@ -1,0 +1,99 @@
+Plotting
+========
+
+We embed some plotting capabilities in the library to help you visualize your data. For simplicity we decided to map all the plotting function to the :doc:`matplotlib <matplotlib:index>` library as it's the most used static plotting library in the Python ecosystem.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   plot-featurecollection
+   plot-image
+   plot-imagecollection
+   map-image
+   map-featurecollection
+
+.. grid:: 1 2 3 3
+
+   .. grid-item::
+
+      .. card:: :icon:`fa-solid fa-chart-simple` FeatureCollection
+         :link: plot-featurecollection.html
+
+   .. grid-item::
+
+      .. card:: :icon:`fa-solid fa-chart-simple` Image
+         :link: plot-image.html
+
+   .. grid-item::
+
+      .. card:: :icon:`fa-solid fa-chart-simple` ImageCollection
+         :link: plot-imagecollection.html
+
+   .. grid-item::
+
+      .. card:: :icon:`fa-solid fa-image` Image
+         :link: map-image.html
+
+   .. grid-item::
+
+      .. card:: :icon:`fa-solid fa-map` FeatureCollection
+         :link: map-featurecollection.html
+
+
+
+In all these examples we will use the object interface of matplotlib creating the :py:class:`Figure <matplotlib.figure.Figure>` and :py:class:`Axes <matplotlib.axes.Axes>` object before plotting the data. This is the recommended way to use matplotlib as it gives you more control over the plot and the figure.
+
+.. code-block:: python
+
+   # custom image for this specific chart
+   modisSr = (
+      ee.ImageCollection("MODIS/061/MOD09A1")
+      .filter(ee.Filter.date("2018-06-01", "2018-09-01"))
+      .select(["sur_refl_b01", "sur_refl_b02", "sur_refl_b06"])
+      .mean()
+   )
+   histRegion = ee.Geometry.Rectangle([-112.60, 40.60, -111.18, 41.22])
+
+   #create a matplotlib figure
+   fig, ax = plt.subplots(figsize=(10, 4))
+
+   # plot the histogram of the reds
+   modisSr.geetools.plot_hist(
+      bands = ["sur_refl_b01", "sur_refl_b02", "sur_refl_b06"],
+      labels = [['Red', 'NIR', 'SWIR']],
+      colors = ["#cf513e", "#1d6b99", "#f0af07"],
+      ax = ax,
+      bins = 100,
+      scale = 500,
+      region = histRegion,
+   )
+
+   # once created the axes can be modified as needed using pure matplotlib functions
+   ax.set_title("Modis SR Reflectance Histogram")
+   ax.set_xlabel("Reflectance (x1e4)")
+
+.. image:: ../../_static/usage/plot/index/histogram.png
+   :alt: Modis SR Reflectance Histogram
+   :align: center
+
+If you are used to the :py:mod:`pyplot <matplotlib.pyplot>` interface of matplotlib you can still use it with the state-base module of matplotlib. Just be aware that the module is a stateful interface and you will have less control over the figure and the plot.
+
+.. code-block:: python
+
+   # get all hydroshed from the the south amercias within the WWF/HydroATLAS dataset.
+   region = ee.Geometry.BBox(-80, -60, -20, 20);
+   fc = ee.FeatureCollection('WWF/HydroATLAS/v1/Basins/level04').filterBounds(region)
+
+   # create the plot
+   fc.geetools.plot(property="UP_AREA", cmap="viridis")
+
+   # Customized display
+   plt.colorbar(ax.collections[0], label="Upstream area (km²)")
+   plt.title("HydroATLAS basins of level4")
+   plt.xlabel("Longitude (°)")
+   plt.ylabel("Latitude (°)")
+
+.. image:: ../../_static/usage/plot/index/hydroshed.png
+   :alt: HydroATLAS basins of level4
+   :align: center

--- a/docs/usage/plot/map-featurecollection.ipynb
+++ b/docs/usage/plot/map-featurecollection.ipynb
@@ -1,0 +1,198 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Map FeatureCollection\n",
+    "\n",
+    "The `geetools` extension contains a set of functions for rendering maps from `ee.FeatureCollection` objects. Use the following function descriptions and examples to determine the best function and chart type for your purpose."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import ee, geetools\n",
+    "from geetools.utils import initialize_documentation\n",
+    "\n",
+    "initialize_documentation()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![github](https://img.shields.io/badge/-see%20sources-white?logo=github&labelColor=555)](https://github.com/gee-community/geetools/blob/main/docs/usage/plot/map-featurecollection.ipynb)\n",
+    "[![colab](https://img.shields.io/badge/-open%20in%20colab-blue?logo=googlecolab&labelColor=555)](https://colab.research.google.com/github/gee-community/geetools/blob/main/docs/usage/plot/map-featurecollection.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up environment\n",
+    "\n",
+    "Install all the required packages and perform the import statement upstream."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# uncomment if installation of libs is necessary\n",
+    "# !pip install earthengine-api geetools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import display\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "import ee\n",
+    "import geetools #noqa: F401"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# uncomment if authetication to GEE is needed\n",
+    "# ee.Authenticate()\n",
+    "# ee.Intialize(project=\"<your_project>\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example data \n",
+    "\n",
+    "The following examples rely on a `ee.FeatureCollection` composed of all the hydroshed bassins from south america."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "region = ee.Geometry.BBox(-80, -60, -20, 20);\n",
+    "fc = ee.FeatureCollection('WWF/HydroATLAS/v1/Basins/level04').filterBounds(region)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Map Vector\n",
+    "\n",
+    "```{api}\n",
+    "{docstring}`ee.FeatureCollection.geetools.plot`\n",
+    "```\n",
+    "\n",
+    "An `ee.FeatureCollection` is a vector representation of geographical properties. A user can be interested by either the property evolution across the landscape or the geometries associated with it. The {py:meth}`plot <geetools.FeatureCollection.FeatureCollectionAccessor.plot>` is coverinig both use cases. \n",
+    "\n",
+    "### Map a property\n",
+    "\n",
+    "A single property can be ploted on a map using matplotlib. The following example is showing the bassin area in km².\n",
+    "\n",
+    "First create a matplotlib figure and axis, then you can add the bassins to the map using the `plot` method. By default it will display the first property of the features. In our case we will opt to display the area of the bassins in km² i.e. the \"UP_AREA\" property. Finally that we have the plot, we can customize it with matplotlib. For example, we can add a title and a colorbar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create the plot\n",
+    "fig, ax = plt.subplots(figsize=(10, 10))\n",
+    "\n",
+    "# generate the graph\n",
+    "fc.geetools.plot(ax=ax, property=\"UP_AREA\", cmap=\"viridis\")\n",
+    "\n",
+    "# you can then customize the figure as you would for any other matplotlib object\n",
+    "fig.colorbar(ax.collections[0], label=\"Upstream area (km²)\")\n",
+    "ax.set_title(\"HydroATLAS basins of level4\")\n",
+    "ax.set_xlabel(\"Longitude (°)\")\n",
+    "ax.set_ylabel(\"Latitude (°)\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Map geometries\n",
+    "\n",
+    "Alternatively if you only want to plot the geometries of the featurecollection on a map, you can use the `plot` method with the `boundares` parameter set to `True`.\n",
+    "\n",
+    "Similarly to the previous example we start by creating a pyplot figure and axis, then you can start plotting the geometries and finally customize the plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.ioff() # remove interactive for the sake of the example\n",
+    "fig, ax = plt.subplots(figsize=(10, 10))\n",
+    "\n",
+    "# create the graph\n",
+    "fc.geetools.plot(ax=ax, boundaries=True)\n",
+    "\n",
+    "# you can then customize the figure as you would for any other matplotlib object\n",
+    "ax.set_title(\"Borders of the HydroATLAS basins of level4\")\n",
+    "ax.set_xlabel(\"Longitude (°)\")\n",
+    "ax.set_ylabel(\"Latitude (°)\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "geetools",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/usage/plot/map-image.ipynb
+++ b/docs/usage/plot/map-image.ipynb
@@ -1,0 +1,218 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Map Image\n",
+    "\n",
+    "The `geetools` extension contains a set of functions for rendering maps from `ee.Image` objects. Use the following function descriptions and examples to determine the best function and chart type for your purpose."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import ee, geetools\n",
+    "from geetools.utils import initialize_documentation\n",
+    "\n",
+    "initialize_documentation()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![github](https://img.shields.io/badge/-see%20sources-white?logo=github&labelColor=555)](https://github.com/gee-community/geetools/blob/main/docs/usage/plot/map-image.ipynb)\n",
+    "[![colab](https://img.shields.io/badge/-open%20in%20colab-blue?logo=googlecolab&labelColor=555)](https://colab.research.google.com/github/gee-community/geetools/blob/main/docs/usage/plot/map-image.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up environment\n",
+    "\n",
+    "Install the required packages and authenticate your Earth Engine account."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# uncomment if installation of libs is necessary\n",
+    "# !pip install earthengine-api geetools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import display\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "import ee\n",
+    "import geetools #noqa: F401"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# uncomment if authetication to GEE is needed\n",
+    "# ee.Authenticate()\n",
+    "# ee.Intialize(project=\"<your_project>\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example data \n",
+    "\n",
+    "The following examples rely on the \"COPERNICUS/S2_HARMONIZED\" `ee.ImageCollection` filtered between 2022-06-01 and 2022-06-30. We then build the NDVI spectral indice and use mosaic to get an `ee.Image` object. This object is clipped over the Vatican city as it's one of the smallest country in the world."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# load the vatican\n",
+    "level0 = ee.FeatureCollection(\"FAO/GAUL/2015/level0\")\n",
+    "vatican = level0.filter(ee.Filter.eq(\"ADM0_NAME\", \"Holy See\"))\n",
+    "\n",
+    "# pre-process the imagecollection and mosaic the month of June 2022\n",
+    "image = (\n",
+    "    ee.ImageCollection('COPERNICUS/S2_HARMONIZED')\n",
+    "    .filterDate('2022-06-01', '2022-06-30')\n",
+    "    .filterBounds(vatican)\n",
+    "    .geetools.maskClouds()\n",
+    "    .geetools.spectralIndices(\"NDVI\")\n",
+    "    .mosaic()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Map Raster\n",
+    "\n",
+    "```{api}\n",
+    "{py:meth}`plot <geetools.Image.ImageAccessor.plot>`: \n",
+    "    {docstring}`geetools.ImageAccessor.plot`\n",
+    "```\n",
+    "\n",
+    "An `ee.image` is a raster representation of the Earth's surface. The `plot` function allows you to visualize the raster data on a map. The function provides options to customize the visualization, such as the color palette, opacity, and the visualization range.\n",
+    "\n",
+    "### Map pseudo color\n",
+    "\n",
+    "A pseudo-color image is a single-band raster image that uses a color palette to represent the data. The following example demonstrates how to plot the NDVI pseudo-color image using the `plot` function.\n",
+    "\n",
+    "First create a matplotlib figure and axis. Then you can add the map to the axis. Provide a single element list in the bands parameter to plot the NDVI image. \n",
+    "As per interactive representation an image needs to be reduced to a region, here \"Vatican City\". In this example we also select a pseudo-mercator projection and we displayed the `ee.FeatureCollection` on top of it. Now that we have the plot, we can customize it with matplotlib. For example, we can add a title and a colorbar. Now that we have the plot, we can customize it with matplotlib. For example, we can add a title and a colorbar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "\n",
+    "image.geetools.plot(\n",
+    "    bands = [\"NDVI\"],\n",
+    "    ax=ax,\n",
+    "    region=vatican.geometry(),\n",
+    "    crs=\"EPSG:3857\",\n",
+    "    scale=10,\n",
+    "    fc=vatican,\n",
+    "    cmap=\"viridis\",\n",
+    "    color=\"k\"\n",
+    ")\n",
+    "\n",
+    "# as it's a figure you can then edit the information as you see fit\n",
+    "ax.set_title(\"NDVI in Vatican City\")\n",
+    "ax.set_xlabel(\"x coordinates (m)\")\n",
+    "ax.set_ylabel(\"y coordinates (m)\")\n",
+    "fig.colorbar(ax.images[0], label=\"NDVI\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Map RGB combo\n",
+    "\n",
+    "An RGB image is a three-band raster image that uses the red, green, and blue bands to represent the data. The following example demonstrates how to plot the RGB image using the `plot` function.\n",
+    "\n",
+    "First create a matplotlib figure and axis. Then you can add the map to the axis. Provide a 3 elements list in the bands parameter to plot the NDVI image. \n",
+    "As per interactive representation an image needs to be reduced to a region, here \"Vatican City\". In this example we displayed the `ee.FeatureCollection` on top of it. Finally customize the plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the plot figure\n",
+    "fig, ax = plt.subplots()\n",
+    "\n",
+    "# Create the graph\n",
+    "image.geetools.plot(\n",
+    "    bands = [\"B4\", \"B3\", \"B2\"],\n",
+    "    ax=ax,\n",
+    "    region=vatican.geometry(),\n",
+    "    fc=vatican,\n",
+    "    color=\"k\"\n",
+    ")\n",
+    "\n",
+    "# as it's a figure you can then edit the information as you see fit\n",
+    "ax.set_title(\"Sentinel 2 composite in Vatican City\")\n",
+    "ax.set_xlabel(\"longitude (°)\")\n",
+    "ax.set_ylabel(\"latitude (°)\")\n",
+    "\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/usage/plot/plot-featurecollection.ipynb
+++ b/docs/usage/plot/plot-featurecollection.ipynb
@@ -1,0 +1,579 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Plot FeatureCollection\n",
+    "\n",
+    "The `geetools` extension contains a set of functions for rendering charts from `ee.FeatureCollection` objects. The choice of function determines the arrangement of data in the chart, i.e., what defines x- and y-axis values and what defines the series. Use the following function descriptions and examples to determine the best function and chart type for your purpose."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import ee, geetools\n",
+    "from geetools.utils import initialize_documentation\n",
+    "\n",
+    "initialize_documentation()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![github](https://img.shields.io/badge/-see%20sources-white?logo=github&labelColor=555)](https://github.com/gee-community/geetools/blob/main/docs/usage/plot/plot-featurecollection.ipynb)\n",
+    "[![colab](https://img.shields.io/badge/-open%20in%20colab-blue?logo=googlecolab&labelColor=555)](https://colab.research.google.com/github/gee-community/geetools/blob/main/docs/usage/plot/plot-featurecollection.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up environment\n",
+    "\n",
+    "Install all the required libs if necessary and perform the import statements upstream."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# uncomment if installation of libs is necessary\n",
+    "# !pip install earthengine-api geetools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "import ee\n",
+    "import geetools #noqa: F401"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# uncomment if authetication to GEE is needed\n",
+    "# ee.Authenticate()\n",
+    "# ee.Intialize(project=\"<your_project>\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example data\n",
+    "\n",
+    "The following examples rely on a FeatureCollection composed of three ecoregion features with properties that describe climate normals."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import the example feature collection.\n",
+    "ecoregions = ee.FeatureCollection('projects/google/charts_feature_example')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot by features\n",
+    "\n",
+    "Features are plotted along the x-axis by values of a selected property. Series are defined by a list of property names whose values are plotted along the y-axis. The type of produced chart can be controlled by the `type` parameter as shown in the following examples.\n",
+    "\n",
+    "If you want to use another plotting library you can get the raw data using the `byFeatures` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "# Data for the chart\n",
+    "features = ['f1', 'f2', 'f3']\n",
+    "p1_values = [0.5, 2.5, 4.5]\n",
+    "p2_values = [1.5, 3.5, 5.5]\n",
+    "p3_values = [2.5, 4.0, 6.5]\n",
+    "\n",
+    "# Set the width of the bars\n",
+    "bar_width = 0.25\n",
+    "index = np.arange(len(features))\n",
+    "offset = 0.005\n",
+    "\n",
+    "# Create the plot\n",
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "# Plotting the bars\n",
+    "rects1 = ax.bar(index, p1_values, bar_width, label='p1', color='#1d6b99')\n",
+    "rects2 = ax.bar(index + (bar_width + offset), p2_values, bar_width, label='p2', color='#cf513e')\n",
+    "rects3 = ax.bar(index + 2 * (bar_width + offset), p3_values, bar_width, label='p3', color='#f0af07')\n",
+    "\n",
+    "# Add labels, title, and custom x-axis tick labels\n",
+    "ax.set_xlabel('Features by property value')\n",
+    "ax.set_ylabel('Series property value')\n",
+    "ax.set_xticks(index + bar_width)\n",
+    "ax.set_xticklabels(features)\n",
+    "\n",
+    "# Add a legend\n",
+    "ax.legend(loc='upper center', bbox_to_anchor=(0.85, 1.15), ncol=3, title='Property names')\n",
+    "\n",
+    "# set the grid display\n",
+    "ax.grid(axis=\"y\")\n",
+    "ax.set_axisbelow(True)\n",
+    "ax.spines[\"top\"].set_visible(False)\n",
+    "ax.spines[\"right\"].set_visible(False)\n",
+    "\n",
+    "# Show the plot\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{api}\n",
+    "- {docstring}`geetools.FeatureCollectionAccessor.plot_by_features`\n",
+    "- {docstring}`ee.FeatureCollection.geetools.byFeatures`\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Column chart\n",
+    "\n",
+    "Features are plotted along the x-axis, labeled by values of a selected property. Series are represented by adjacent columns defined by a list of property names whose values are plotted along the y-axis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "# initialize the plot with the ecoregions data\n",
+    "ecoregions.geetools.plot_by_features(\n",
+    "    type = \"bar\",\n",
+    "    featureId = \"label\",\n",
+    "    properties = ['01_tmean', '02_tmean', '03_tmean', '04_tmean', '05_tmean', '06_tmean', '07_tmean', '08_tmean', '09_tmean', '10_tmean', '11_tmean', '12_tmean'],\n",
+    "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
+    "    colors = ['#604791', '#1d6b99', '#39a8a7', '#0f8755', '#76b349', '#f0af07', '#e37d05', '#cf513e', '#96356f', '#724173', '#9c4f97', '#696969'],\n",
+    "    ax = ax\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "ax.set_title(\"Average Monthly Temperature by Ecoregion\")\n",
+    "ax.set_xlabel(\"Ecoregion\")\n",
+    "ax.set_ylabel(\"Temperature (°C)\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Stacked column chart\n",
+    "\n",
+    "Features are plotted along the x-axis, labeled by values of a selected property. Series are represented by stacked columns defined by a list of property names whose values are plotted along the y-axis as the cumulative series sum."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "# initialize theplot with the ecoregions data\n",
+    "ecoregions.geetools.plot_by_features(\n",
+    "    type = \"stacked\",\n",
+    "    featureId = \"label\",\n",
+    "    properties = ['01_ppt', '02_ppt', '03_ppt', '04_ppt', '05_ppt', '06_ppt', '07_ppt', '08_ppt', '09_ppt', '10_ppt', '11_ppt', '12_ppt'],\n",
+    "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
+    "    colors = ['#604791', '#1d6b99', '#39a8a7', '#0f8755', '#76b349', '#f0af07', '#e37d05', '#cf513e', '#96356f', '#724173', '#9c4f97', '#696969'],\n",
+    "    ax = ax\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "ax.set_title(\"Average Monthly Precipitation by Ecoregion\")\n",
+    "ax.set_xlabel(\"Ecoregion\")\n",
+    "ax.set_ylabel(\"Precipitation (mm)\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Scatter chart\n",
+    "\n",
+    "Features are plotted along the x-axis, labeled by values of a selected property. Series are represented by points defined by a list of property names whose values are plotted along the y-axis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "# initialize theplot with the ecoregions data\n",
+    "ecoregions.geetools.plot_by_features(\n",
+    "    type = \"scatter\",\n",
+    "    featureId = \"label\",\n",
+    "    properties = ['01_ppt', '06_ppt', '09_ppt'],\n",
+    "    labels = [\"jan\", \"jun\", \"sep\"],\n",
+    "    ax = ax\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "ax.set_title(\"Average Monthly Precipitation by Ecoregion\")\n",
+    "ax.set_xlabel(\"Ecoregion\")\n",
+    "ax.set_ylabel(\"Precipitation (mm)\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pie chart\n",
+    "\n",
+    "The pie is a property, each slice is the share from each feature whose value is cast as a percentage of the sum of all values of features composing the pie."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "# initialize theplot with the ecoregions data\n",
+    "ecoregions.geetools.plot_by_features(\n",
+    "    type = \"pie\",\n",
+    "    featureId = \"label\",\n",
+    "    properties = ['06_ppt'],\n",
+    "    colors = [\"#f0af07\", \"#0f8755\", \"#76b349\"],\n",
+    "    ax = ax\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "ax.set_title(\"Share of precipitation in June by Ecoregion\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Donut chart\n",
+    "\n",
+    "The donut is a property, each slice is the share from each feature whose value is cast as a percentage of the sum of all values of features composing the donut."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "# initialize theplot with the ecoregions data\n",
+    "ecoregions.geetools.plot_by_features(\n",
+    "    type = \"donut\",\n",
+    "    featureId = \"label\",\n",
+    "    properties = ['07_ppt'],\n",
+    "    colors = [\"#f0af07\", \"#0f8755\", \"#76b349\"],\n",
+    "    ax = ax\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "ax.set_title(\"Share of precipitation in July by Ecoregion\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot by properties\n",
+    "\n",
+    "Feature properties are plotted along the x-axis by name; values of the given properties are plotted along the y-axis. Series are features labeled by values of a selected property. The type of produced chart can be controlled by the `type` parameter as shown in the following examples."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "# Data for the chart\n",
+    "features = ['p1', 'p2', 'p3']\n",
+    "p1_values = [0.5, 2.5, 4.5]\n",
+    "p2_values = [1.5, 3.5, 5.5]\n",
+    "p3_values = [2.5, 4.0, 6.5]\n",
+    "\n",
+    "# Set the width of the bars\n",
+    "bar_width = 0.25\n",
+    "index = np.arange(len(features))\n",
+    "offset = 0.005\n",
+    "\n",
+    "# Create the plot\n",
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "# Plotting the bars\n",
+    "rects1 = ax.bar(index, p1_values, bar_width, label='f1', color='#1d6b99')\n",
+    "rects2 = ax.bar(index + (bar_width + offset), p2_values, bar_width, label='f2', color='#cf513e')\n",
+    "rects3 = ax.bar(index + 2 * (bar_width + offset), p3_values, bar_width, label='f3', color='#f0af07')\n",
+    "\n",
+    "# Add labels, title, and custom x-axis tick labels\n",
+    "ax.set_xlabel('Property names')\n",
+    "ax.set_ylabel('Series property value')\n",
+    "ax.set_xticks(index + bar_width)\n",
+    "ax.set_xticklabels(features)\n",
+    "\n",
+    "# Add a legend\n",
+    "ax.legend(loc='upper center', bbox_to_anchor=(0.85, 1.15), ncol=3, title='Features by property value')\n",
+    "\n",
+    "# set the grid display\n",
+    "ax.grid(axis=\"y\")\n",
+    "ax.set_axisbelow(True)\n",
+    "ax.spines[\"top\"].set_visible(False)\n",
+    "ax.spines[\"right\"].set_visible(False)\n",
+    "\n",
+    "# Show the plot\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{api}\n",
+    "- {docstring}`ee.FeatureCollection.geetools.plot_by_properties`\n",
+    "- {docstring}`ee.FeatureCollection.geetools.byProperties`\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Column chart\n",
+    "\n",
+    "Feature properties are plotted along the x-axis, labeled and sorted by a dictionary input; the values of the given properties are plotted along the y-axis. Series are features, represented by columns, labeled by values of a selected property."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "\n",
+    "# initialize theplot with the ecoregions data\n",
+    "ax = ecoregions.geetools.plot_by_properties(\n",
+    "    type = \"bar\",\n",
+    "    properties = ['01_ppt', '02_ppt', '03_ppt', '04_ppt', '05_ppt', '06_ppt', '07_ppt', '08_ppt', '09_ppt', '10_ppt', '11_ppt', '12_ppt'],\n",
+    "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
+    "    featureId = \"label\",\n",
+    "    colors = [\"#f0af07\", \"#0f8755\", \"#76b349\"],\n",
+    "    ax = ax\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "ax.set_title(\"Average Monthly Precipitation by Ecoregion\")\n",
+    "ax.set_xlabel(\"Month\")\n",
+    "ax.set_ylabel(\"Precipitation (mm)\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Line chart\n",
+    "\n",
+    "Feature properties are plotted along the x-axis, labeled and sorted by a dictionary input; the values of the given properties are plotted along the y-axis. Series are features, represented by columns, labeled by values of a selected property."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "# initialize theplot with the ecoregions data\n",
+    "ax = ecoregions.geetools.plot_by_properties(\n",
+    "    type = \"plot\",\n",
+    "    properties = [\"01_ppt\", \"02_ppt\", \"03_ppt\", \"04_ppt\", \"05_ppt\", \"06_ppt\", \"07_ppt\", \"08_ppt\", \"09_ppt\", \"10_ppt\", \"11_ppt\", \"12_ppt\"],\n",
+    "    featureId = \"label\",\n",
+    "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
+    "    colors = [\"#f0af07\", \"#0f8755\", \"#76b349\"],\n",
+    "    ax = ax\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "ax.set_title(\"Average Monthly Precipitation by Ecoregion\")\n",
+    "ax.set_xlabel(\"Month\")\n",
+    "ax.set_ylabel(\"Precipitation (mm)\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Area chart \n",
+    "\n",
+    "Feature properties are plotted along the x-axis, labeled and sorted by a dictionary input; the values of the given properties are plotted along the y-axis. Series are features, represented by lines and shaded areas, labeled by values of a selected property."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "# initialize the plot with the ecoregions data\n",
+    "ax = ecoregions.geetools.plot_by_properties(\n",
+    "    type = \"fill_between\",\n",
+    "    properties = [\"01_ppt\", \"02_ppt\", \"03_ppt\", \"04_ppt\", \"05_ppt\", \"06_ppt\", \"07_ppt\", \"08_ppt\", \"09_ppt\", \"10_ppt\", \"11_ppt\", \"12_ppt\"],\n",
+    "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
+    "    featureId = \"label\",\n",
+    "    colors = [\"#f0af07\", \"#0f8755\", \"#76b349\"],\n",
+    "    ax = ax\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "ax.set_title(\"Average Monthly Precipitation by Ecoregion\")\n",
+    "ax.set_xlabel(\"Month\")\n",
+    "ax.set_ylabel(\"Precipitation (mm)\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot hist\n",
+    "\n",
+    "```{api}\n",
+    "{docstring}`ee.FeatureCollection.geetools.plot_hist`\n",
+    "```\n",
+    "\n",
+    "The x-axis is defined by value bins for the range of values of a selected property; the y-axis is the number of elements in the given bin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "# load some data\n",
+    "normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()\n",
+    "\n",
+    "# Make a point sample of climate variables for a region in western USA.\n",
+    "region = ee.Geometry.Rectangle(-123.41, 40.43, -116.38, 45.14)\n",
+    "climSamp = normClim.sample(region, 5000)\n",
+    "\n",
+    "\n",
+    "# initialize the plot with the ecoregions data\n",
+    "ax = climSamp.geetools.plot_hist(\n",
+    "    property = \"07_ppt\",\n",
+    "    label = \"July Precipitation (mm)\",\n",
+    "    color = '#1d6b99',\n",
+    "    ax = ax,\n",
+    "    bins = 30\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "ax.set_title(\"July Precipitation Distribution for NW USA\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/usage/plot/plot-featurecollection.ipynb
+++ b/docs/usage/plot/plot-featurecollection.ipynb
@@ -29,8 +29,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![github](https://img.shields.io/badge/-see%20sources-white?logo=github&labelColor=555)](https://github.com/gee-community/geetools/blob/main/docs/usage/plot/plot-featurecollection.ipynb)\n",
-    "[![colab](https://img.shields.io/badge/-open%20in%20colab-blue?logo=googlecolab&labelColor=555)](https://colab.research.google.com/github/gee-community/geetools/blob/main/docs/usage/plot/plot-featurecollection.ipynb)"
+    "[![github](https://img.shields.io/badge/-see%20sources-white?logo=github&labelColor=555)](https://github.com/gee-community/ipygee/blob/main/docs/usage/plot/plot-featurecollection.ipynb)\n",
+    "[![colab](https://img.shields.io/badge/-open%20in%20colab-blue?logo=googlecolab&labelColor=555)](https://colab.research.google.com/github/gee-community/ipygee/blob/main/docs/usage/plot/plot-featurecollection.ipynb)"
    ]
   },
   {
@@ -61,7 +61,10 @@
     "from matplotlib import pyplot as plt\n",
     "\n",
     "import ee\n",
-    "import geetools #noqa: F401"
+    "import ipygee #noqa: F401\n",
+    "from bokeh.io import output_notebook\n",
+    "\n",
+    "output_notebook()"
    ]
   },
   {
@@ -72,7 +75,7 @@
    "source": [
     "# uncomment if authetication to GEE is needed\n",
     "# ee.Authenticate()\n",
-    "# ee.Intialize(project=\"<your_project>\")"
+    "# ee.Initialize(project=\"<your_project>\")"
    ]
   },
   {
@@ -115,7 +118,7 @@
    },
    "outputs": [],
    "source": [
-    "import matplotlib.pyplot as plt\n",
+    "from bokeh.plotting import figure, show\n",
     "import numpy as np\n",
     "\n",
     "# Data for the chart\n",
@@ -127,44 +130,29 @@
     "# Set the width of the bars\n",
     "bar_width = 0.25\n",
     "index = np.arange(len(features))\n",
-    "offset = 0.005\n",
+    "offset = 0.02\n",
     "\n",
     "# Create the plot\n",
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
     "# Plotting the bars\n",
-    "rects1 = ax.bar(index, p1_values, bar_width, label='p1', color='#1d6b99')\n",
-    "rects2 = ax.bar(index + (bar_width + offset), p2_values, bar_width, label='p2', color='#cf513e')\n",
-    "rects3 = ax.bar(index + 2 * (bar_width + offset), p3_values, bar_width, label='p3', color='#f0af07')\n",
+    "rects1 = fig.vbar(x=index, top=p1_values, width=bar_width, legend_label='p1', color='#1d6b99')\n",
+    "rects2 = fig.vbar(x=index + (bar_width + offset), top=p2_values, width=bar_width, legend_label='p2', color='#cf513e')\n",
+    "rects3 = fig.vbar(x=index + 2 * (bar_width + offset), top=p3_values, width=bar_width, legend_label='p3', color='#f0af07')\n",
     "\n",
     "# Add labels, title, and custom x-axis tick labels\n",
-    "ax.set_xlabel('Features by property value')\n",
-    "ax.set_ylabel('Series property value')\n",
-    "ax.set_xticks(index + bar_width)\n",
-    "ax.set_xticklabels(features)\n",
-    "\n",
-    "# Add a legend\n",
-    "ax.legend(loc='upper center', bbox_to_anchor=(0.85, 1.15), ncol=3, title='Property names')\n",
-    "\n",
-    "# set the grid display\n",
-    "ax.grid(axis=\"y\")\n",
-    "ax.set_axisbelow(True)\n",
-    "ax.spines[\"top\"].set_visible(False)\n",
-    "ax.spines[\"right\"].set_visible(False)\n",
+    "fig.yaxis.axis_label = \"Series property value\"\n",
+    "fig.xaxis.axis_label = \"Features by property value\"\n",
+    "fig.outline_line_color = None\n",
+    "fig.legend.title = \"Property names\"\n",
+    "fig.legend.location = \"top_left\"\n",
+    "fig.xaxis.ticker = index + (bar_width + offset)\n",
+    "fig.xaxis.major_label_overrides = dict(zip(index + (bar_width + offset), features))\n",
+    "fig.xgrid.grid_line_color = None\n",
+    "fig.legend.orientation = \"horizontal\"\n",
     "\n",
     "# Show the plot\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{api}\n",
-    "- {docstring}`geetools.FeatureCollectionAccessor.plot_by_features`\n",
-    "- {docstring}`ee.FeatureCollection.geetools.byFeatures`\n",
-    "```"
+    "show(fig)"
    ]
   },
   {
@@ -182,23 +170,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
     "# initialize the plot with the ecoregions data\n",
-    "ecoregions.geetools.plot_by_features(\n",
+    "ecoregions.bokeh.plot_by_features(\n",
     "    type = \"bar\",\n",
     "    featureId = \"label\",\n",
     "    properties = ['01_tmean', '02_tmean', '03_tmean', '04_tmean', '05_tmean', '06_tmean', '07_tmean', '08_tmean', '09_tmean', '10_tmean', '11_tmean', '12_tmean'],\n",
     "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
     "    colors = ['#604791', '#1d6b99', '#39a8a7', '#0f8755', '#76b349', '#f0af07', '#e37d05', '#cf513e', '#96356f', '#724173', '#9c4f97', '#696969'],\n",
-    "    ax = ax\n",
+    "    figure = fig\n",
     ")\n",
     "\n",
-    "# once created the axes can be modified as needed using pure matplotlib functions\n",
-    "ax.set_title(\"Average Monthly Temperature by Ecoregion\")\n",
-    "ax.set_xlabel(\"Ecoregion\")\n",
-    "ax.set_ylabel(\"Temperature (°C)\")\n",
-    "plt.show()"
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Average Monthly Temperature by Ecoregion\"\n",
+    "fig.xaxis.axis_label = \"Ecoregion\"\n",
+    "fig.yaxis.axis_label = \"Temperature (°C)\"\n",
+    "\n",
+    "show(fig)"
    ]
   },
   {
@@ -216,23 +205,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
     "# initialize theplot with the ecoregions data\n",
-    "ecoregions.geetools.plot_by_features(\n",
+    "ecoregions.bokeh.plot_by_features(\n",
     "    type = \"stacked\",\n",
     "    featureId = \"label\",\n",
     "    properties = ['01_ppt', '02_ppt', '03_ppt', '04_ppt', '05_ppt', '06_ppt', '07_ppt', '08_ppt', '09_ppt', '10_ppt', '11_ppt', '12_ppt'],\n",
     "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
     "    colors = ['#604791', '#1d6b99', '#39a8a7', '#0f8755', '#76b349', '#f0af07', '#e37d05', '#cf513e', '#96356f', '#724173', '#9c4f97', '#696969'],\n",
-    "    ax = ax\n",
+    "    figure = fig\n",
     ")\n",
     "\n",
-    "# once created the axes can be modified as needed using pure matplotlib functions\n",
-    "ax.set_title(\"Average Monthly Precipitation by Ecoregion\")\n",
-    "ax.set_xlabel(\"Ecoregion\")\n",
-    "ax.set_ylabel(\"Precipitation (mm)\")\n",
-    "plt.show()"
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Average Monthly Precipitation by Ecoregion\"\n",
+    "fig.xaxis.axis_label = \"Ecoregion\"\n",
+    "fig.yaxis.axis_label = \"Precipitation (mm)\"\n",
+    "\n",
+    "show(fig)"
    ]
   },
   {
@@ -250,22 +240,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
     "# initialize theplot with the ecoregions data\n",
-    "ecoregions.geetools.plot_by_features(\n",
+    "ecoregions.bokeh.plot_by_features(\n",
     "    type = \"scatter\",\n",
     "    featureId = \"label\",\n",
     "    properties = ['01_ppt', '06_ppt', '09_ppt'],\n",
     "    labels = [\"jan\", \"jun\", \"sep\"],\n",
-    "    ax = ax\n",
+    "    figure = fig\n",
     ")\n",
     "\n",
-    "# once created the axes can be modified as needed using pure matplotlib functions\n",
-    "ax.set_title(\"Average Monthly Precipitation by Ecoregion\")\n",
-    "ax.set_xlabel(\"Ecoregion\")\n",
-    "ax.set_ylabel(\"Precipitation (mm)\")\n",
-    "plt.show()"
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Average Monthly Precipitation by Ecoregion\"\n",
+    "fig.xaxis.axis_label = \"Ecoregion\"\n",
+    "fig.yaxis.axis_label = \"Precipitation (mm)\"\n",
+    "\n",
+    "show(fig)"
    ]
   },
   {
@@ -283,20 +274,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "fig = figure(match_aspect=True)\n",
     "\n",
     "# initialize theplot with the ecoregions data\n",
-    "ecoregions.geetools.plot_by_features(\n",
+    "ecoregions.bokeh.plot_by_features(\n",
     "    type = \"pie\",\n",
     "    featureId = \"label\",\n",
     "    properties = ['06_ppt'],\n",
     "    colors = [\"#f0af07\", \"#0f8755\", \"#76b349\"],\n",
-    "    ax = ax\n",
+    "    figure = fig\n",
     ")\n",
     "\n",
-    "# once created the axes can be modified as needed using pure matplotlib functions\n",
-    "ax.set_title(\"Share of precipitation in June by Ecoregion\")\n",
-    "plt.show()"
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Share of precipitation in June by Ecoregion\"\n",
+    "\n",
+    "show(fig)"
    ]
   },
   {
@@ -314,20 +306,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "fig = figure(match_aspect=True)\n",
     "\n",
     "# initialize theplot with the ecoregions data\n",
-    "ecoregions.geetools.plot_by_features(\n",
+    "ecoregions.bokeh.plot_by_features(\n",
     "    type = \"donut\",\n",
     "    featureId = \"label\",\n",
     "    properties = ['07_ppt'],\n",
     "    colors = [\"#f0af07\", \"#0f8755\", \"#76b349\"],\n",
-    "    ax = ax\n",
+    "    figure = fig\n",
     ")\n",
     "\n",
-    "# once created the axes can be modified as needed using pure matplotlib functions\n",
-    "ax.set_title(\"Share of precipitation in July by Ecoregion\")\n",
-    "plt.show()"
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Share of precipitation in July by Ecoregion\"\n",
+    "\n",
+    "show(fig)"
    ]
   },
   {
@@ -349,7 +342,7 @@
    },
    "outputs": [],
    "source": [
-    "import matplotlib.pyplot as plt\n",
+    "from bokeh.plotting import figure, show\n",
     "import numpy as np\n",
     "\n",
     "# Data for the chart\n",
@@ -361,44 +354,29 @@
     "# Set the width of the bars\n",
     "bar_width = 0.25\n",
     "index = np.arange(len(features))\n",
-    "offset = 0.005\n",
+    "offset = 0.02\n",
     "\n",
     "# Create the plot\n",
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
     "# Plotting the bars\n",
-    "rects1 = ax.bar(index, p1_values, bar_width, label='f1', color='#1d6b99')\n",
-    "rects2 = ax.bar(index + (bar_width + offset), p2_values, bar_width, label='f2', color='#cf513e')\n",
-    "rects3 = ax.bar(index + 2 * (bar_width + offset), p3_values, bar_width, label='f3', color='#f0af07')\n",
+    "rects1 = fig.vbar(x=index, top=p1_values, width=bar_width, legend_label='f1', color='#1d6b99')\n",
+    "rects2 = fig.vbar(x=index + (bar_width + offset), top=p2_values, width=bar_width, legend_label='f2', color='#cf513e')\n",
+    "rects3 = fig.vbar(x=index + 2 * (bar_width + offset), top=p3_values, width=bar_width, legend_label='f3', color='#f0af07')\n",
     "\n",
     "# Add labels, title, and custom x-axis tick labels\n",
-    "ax.set_xlabel('Property names')\n",
-    "ax.set_ylabel('Series property value')\n",
-    "ax.set_xticks(index + bar_width)\n",
-    "ax.set_xticklabels(features)\n",
-    "\n",
-    "# Add a legend\n",
-    "ax.legend(loc='upper center', bbox_to_anchor=(0.85, 1.15), ncol=3, title='Features by property value')\n",
-    "\n",
-    "# set the grid display\n",
-    "ax.grid(axis=\"y\")\n",
-    "ax.set_axisbelow(True)\n",
-    "ax.spines[\"top\"].set_visible(False)\n",
-    "ax.spines[\"right\"].set_visible(False)\n",
+    "fig.yaxis.axis_label = \"Series property value\"\n",
+    "fig.xaxis.axis_label = \"Property names\"\n",
+    "fig.outline_line_color = None\n",
+    "fig.legend.title = \"Features by property value\"\n",
+    "fig.legend.location = \"top_left\"\n",
+    "fig.xaxis.ticker = index + (bar_width + offset)\n",
+    "fig.xaxis.major_label_overrides = dict(zip(index + (bar_width + offset), features))\n",
+    "fig.xgrid.grid_line_color = None\n",
+    "fig.legend.orientation = \"horizontal\"\n",
     "\n",
     "# Show the plot\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{api}\n",
-    "- {docstring}`ee.FeatureCollection.geetools.plot_by_properties`\n",
-    "- {docstring}`ee.FeatureCollection.geetools.byProperties`\n",
-    "```"
+    "show(fig)"
    ]
   },
   {
@@ -416,24 +394,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
     "\n",
     "# initialize theplot with the ecoregions data\n",
-    "ax = ecoregions.geetools.plot_by_properties(\n",
+    "ecoregions.bokeh.plot_by_properties(\n",
     "    type = \"bar\",\n",
     "    properties = ['01_ppt', '02_ppt', '03_ppt', '04_ppt', '05_ppt', '06_ppt', '07_ppt', '08_ppt', '09_ppt', '10_ppt', '11_ppt', '12_ppt'],\n",
     "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
     "    featureId = \"label\",\n",
     "    colors = [\"#f0af07\", \"#0f8755\", \"#76b349\"],\n",
-    "    ax = ax\n",
+    "    figure = fig\n",
     ")\n",
     "\n",
-    "# once created the axes can be modified as needed using pure matplotlib functions\n",
-    "ax.set_title(\"Average Monthly Precipitation by Ecoregion\")\n",
-    "ax.set_xlabel(\"Month\")\n",
-    "ax.set_ylabel(\"Precipitation (mm)\")\n",
-    "plt.show()"
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Average Monthly Precipitation by Ecoregion\"\n",
+    "fig.xaxis.axis_label = \"Month\"\n",
+    "fig.yaxis.axis_label = \"Precipitation (mm)\"\n",
+    "\n",
+    "show(fig)"
    ]
   },
   {
@@ -451,23 +430,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
     "# initialize theplot with the ecoregions data\n",
-    "ax = ecoregions.geetools.plot_by_properties(\n",
+    "ecoregions.bokeh.plot_by_properties(\n",
     "    type = \"plot\",\n",
     "    properties = [\"01_ppt\", \"02_ppt\", \"03_ppt\", \"04_ppt\", \"05_ppt\", \"06_ppt\", \"07_ppt\", \"08_ppt\", \"09_ppt\", \"10_ppt\", \"11_ppt\", \"12_ppt\"],\n",
     "    featureId = \"label\",\n",
     "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
     "    colors = [\"#f0af07\", \"#0f8755\", \"#76b349\"],\n",
-    "    ax = ax\n",
+    "    figure = fig\n",
     ")\n",
     "\n",
-    "# once created the axes can be modified as needed using pure matplotlib functions\n",
-    "ax.set_title(\"Average Monthly Precipitation by Ecoregion\")\n",
-    "ax.set_xlabel(\"Month\")\n",
-    "ax.set_ylabel(\"Precipitation (mm)\")\n",
-    "plt.show()"
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Average Monthly Precipitation by Ecoregion\"\n",
+    "fig.xaxis.axis_label = \"Month\"\n",
+    "fig.yaxis.axis_label = \"Precipitation (mm)\"\n",
+    "\n",
+    "show(fig)"
    ]
   },
   {
@@ -485,23 +465,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
     "# initialize the plot with the ecoregions data\n",
-    "ax = ecoregions.geetools.plot_by_properties(\n",
+    "ecoregions.bokeh.plot_by_properties(\n",
     "    type = \"fill_between\",\n",
     "    properties = [\"01_ppt\", \"02_ppt\", \"03_ppt\", \"04_ppt\", \"05_ppt\", \"06_ppt\", \"07_ppt\", \"08_ppt\", \"09_ppt\", \"10_ppt\", \"11_ppt\", \"12_ppt\"],\n",
     "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
     "    featureId = \"label\",\n",
     "    colors = [\"#f0af07\", \"#0f8755\", \"#76b349\"],\n",
-    "    ax = ax\n",
+    "    figure = fig\n",
     ")\n",
     "\n",
-    "# once created the axes can be modified as needed using pure matplotlib functions\n",
-    "ax.set_title(\"Average Monthly Precipitation by Ecoregion\")\n",
-    "ax.set_xlabel(\"Month\")\n",
-    "ax.set_ylabel(\"Precipitation (mm)\")\n",
-    "plt.show()"
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Average Monthly Precipitation by Ecoregion\"\n",
+    "fig.xaxis.axis_label = \"Month\"\n",
+    "fig.yaxis.axis_label = \"Precipitation (mm)\"\n",
+    "\n",
+    "show(fig)"
    ]
   },
   {
@@ -523,7 +504,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
     "# load some data\n",
     "normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()\n",
@@ -534,17 +515,18 @@
     "\n",
     "\n",
     "# initialize the plot with the ecoregions data\n",
-    "ax = climSamp.geetools.plot_hist(\n",
+    "climSamp.bokeh.plot_hist(\n",
     "    property = \"07_ppt\",\n",
     "    label = \"July Precipitation (mm)\",\n",
     "    color = '#1d6b99',\n",
-    "    ax = ax,\n",
+    "    figure = fig,\n",
     "    bins = 30\n",
     ")\n",
     "\n",
-    "# once created the axes can be modified as needed using pure matplotlib functions\n",
-    "ax.set_title(\"July Precipitation Distribution for NW USA\")\n",
-    "plt.show()"
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"July Precipitation Distribution for NW USA\"\n",
+    "\n",
+    "show(fig)"
    ]
   },
   {
@@ -557,7 +539,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "ipygee",
    "language": "python",
    "name": "python3"
   },
@@ -571,7 +553,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/docs/usage/plot/plot-image.ipynb
+++ b/docs/usage/plot/plot-image.ipynb
@@ -1,0 +1,583 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Plot Image\n",
+    "\n",
+    "The `geetools` extention contains a set of functions for reducing `ee.Image` objects by region(s) and rendering charts from the results. The choice of function dictates the arrangement of data in the chart, i.e., what defines x- and y-axis values and what defines the series. Use the following function descriptions and examples to determine the best function and chart type for your purpose.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import ee, geetools\n",
+    "from geetools.utils import initialize_documentation\n",
+    "\n",
+    "initialize_documentation()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![github](https://img.shields.io/badge/-see%20sources-white?logo=github&labelColor=555)](https://github.com/gee-community/ipygee/blob/main/docs/usage/plot/plot-image.ipynb)\n",
+    "[![colab](https://img.shields.io/badge/-open%20in%20colab-blue?logo=googlecolab&labelColor=555)](https://colab.research.google.com/github/gee-community/ipygee/blob/main/docs/usage/plot/plot-image.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up environment\n",
+    "\n",
+    "Install all the requireed libs if necessary. and perform the import satements upstream."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# uncomment if installation of libs is necessary\n",
+    "# !pip install earthengine-api geetools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ee\n",
+    "import ipygee #noqa: F401\n",
+    "from bokeh.io import output_notebook\n",
+    "\n",
+    "output_notebook()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# uncomment if authetication to GEE is needed\n",
+    "# ee.Authenticate()\n",
+    "#ee.Initialize(project=\"<your project>\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example data\n",
+    "\n",
+    "The following examples rely on a `ee.FeatureCollection` composed of three ecoregion features that define regions by which to reduce image data. The Image data are PRISM climate normals, where bands describe climate variables per month; e.g., July precipitation or January mean temperature.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ecoregions = ee.FeatureCollection(\"projects/google/charts_feature_example\").select([\"label\", \"value\",\"warm\"])\n",
+    "normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot by regions\n",
+    "\n",
+    "Reduction regions are plotted along the x-axis, labeled by values of a selected feature property. Series are defined by band names whose region reduction results are plotted along the y-axis.\n",
+    "\n",
+    "If you want to use another plotting library, you can use the `byRegions` function to get the data and plot it with your favorite library.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from bokeh.plotting import figure, show\n",
+    "import numpy as np\n",
+    "\n",
+    "# Data for the chart\n",
+    "features = ['r1', 'r2', 'r3']\n",
+    "p1_values = [0.5, 2.5, 4.5]\n",
+    "p2_values = [1.5, 3.5, 5.5]\n",
+    "p3_values = [2.5, 4.0, 6.5]\n",
+    "\n",
+    "# Set the width of the bars\n",
+    "bar_width = 0.25\n",
+    "index = np.arange(len(features))\n",
+    "offset = 0.02\n",
+    "\n",
+    "# Create the plot\n",
+    "fig = figure(width=800, height=400)\n",
+    "\n",
+    "# Plotting the bars\n",
+    "rects1 = fig.vbar(x=index, top=p1_values, width=bar_width, legend_label='b1', color='#1d6b99')\n",
+    "rects2 = fig.vbar(x=index + (bar_width + offset), top=p2_values, width=bar_width, legend_label='b2', color='#cf513e')\n",
+    "rects3 = fig.vbar(x=index + 2 * (bar_width + offset), top=p3_values, width=bar_width, legend_label='b3', color='#f0af07')\n",
+    "\n",
+    "# Add labels, title, and custom x-axis tick labels\n",
+    "fig.yaxis.axis_label = \"Series reduction value\"\n",
+    "fig.xaxis.axis_label = \"Regions by feature property value\"\n",
+    "fig.outline_line_color = None\n",
+    "fig.legend.title = \"Band names\"\n",
+    "fig.legend.location = \"top_left\"\n",
+    "fig.xaxis.ticker = index + (bar_width + offset)\n",
+    "fig.xaxis.major_label_overrides = dict(zip(index + (bar_width + offset), features))\n",
+    "fig.xgrid.grid_line_color = None\n",
+    "fig.legend.orientation = \"horizontal\"\n",
+    "\n",
+    "# Show the plot\n",
+    "show(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Column chart\n",
+    "\n",
+    "In this example, image bands representing average monthly temperature are reduced to the mean among pixels intersecting each of three ecoregions. The results are plotted as columns per month by ecoregion, where column height indicates the respective mean monthly temperature."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = figure(width=800, height=400)\n",
+    "\n",
+    "normClim.bokeh.plot_by_regions(\n",
+    "    type = \"bar\",\n",
+    "    regions = ecoregions,\n",
+    "    reducer = \"mean\",\n",
+    "    scale = 500,\n",
+    "    regionId = \"label\",\n",
+    "    bands = [\"01_tmean\", \"02_tmean\", \"03_tmean\", \"04_tmean\", \"05_tmean\", \"06_tmean\", \"07_tmean\", \"08_tmean\", \"09_tmean\", \"10_tmean\", \"11_tmean\", \"12_tmean\"],\n",
+    "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
+    "    colors = ['#604791', '#1d6b99', '#39a8a7', '#0f8755', '#76b349', '#f0af07', '#e37d05', '#cf513e', '#96356f', '#724173', '#9c4f97', '#696969'],\n",
+    "    figure = fig\n",
+    ")\n",
+    "\n",
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Average Monthly Temperature by Ecoregion\"\n",
+    "fig.xaxis.axis_label = \"Ecoregion\"\n",
+    "fig.yaxis.axis_label = \"Temperature (°C)\"\n",
+    "\n",
+    "show(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bar chart \n",
+    "\n",
+    "The previous column chart can be swiped from vertical column to horizontal bars a bar chart by changing the `type` input from 'bar' to 'barh'."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = figure(width=800, height=400)\n",
+    "\n",
+    "normClim.bokeh.plot_by_regions(\n",
+    "    type = \"barh\",\n",
+    "    regions = ecoregions,\n",
+    "    reducer = \"mean\",\n",
+    "    scale = 500,\n",
+    "    regionId = \"label\",\n",
+    "    bands = [\"01_tmean\", \"02_tmean\", \"03_tmean\", \"04_tmean\", \"05_tmean\", \"06_tmean\", \"07_tmean\", \"08_tmean\", \"09_tmean\", \"10_tmean\", \"11_tmean\", \"12_tmean\"],\n",
+    "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
+    "    colors = ['#604791', '#1d6b99', '#39a8a7', '#0f8755', '#76b349', '#f0af07', '#e37d05', '#cf513e', '#96356f', '#724173', '#9c4f97', '#696969'],\n",
+    "    figure = fig\n",
+    ")\n",
+    "\n",
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Average Monthly Temperature by Ecoregion\"\n",
+    "fig.yaxis.axis_label = \"Ecoregion\"\n",
+    "fig.xaxis.axis_label = \"Temperature (°C)\"\n",
+    "show(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Stacked bar chart \n",
+    "\n",
+    "An absolute stacked bar chart relates the total of a numeric variable by increments of a contributing categorical variable series. For instance, in this example, total precipitation is plotted as the accumulation of monthly precipitation over a year, by ecoregion. Monthly precipitation totals are derived from image bands, where each band represents a grid of average total precipitation for a given month, reduced to the mean of the pixels intersecting each of three ecoregions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = figure(width=800, height=400)\n",
+    "\n",
+    "normClim.bokeh.plot_by_regions(\n",
+    "    type = \"stacked\",\n",
+    "    regions = ecoregions,\n",
+    "    reducer = \"mean\",\n",
+    "    scale = 500,\n",
+    "    regionId = \"label\",\n",
+    "    bands = ['01_ppt', '02_ppt', '03_ppt', '04_ppt', '05_ppt', '06_ppt', '07_ppt', '08_ppt', '09_ppt', '10_ppt', '11_ppt', '12_ppt'],\n",
+    "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
+    "    colors = ['#604791', '#1d6b99', '#39a8a7', '#0f8755', '#76b349', '#f0af07', '#e37d05', '#cf513e', '#96356f', '#724173', '#9c4f97', '#696969'],\n",
+    "    figure = fig\n",
+    ")\n",
+    "\n",
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Average Monthly Temperature by Ecoregion\"\n",
+    "fig.xaxis.axis_label = \"Ecoregion\"\n",
+    "fig.yaxis.axis_label = \"Temperature (°C)\"\n",
+    "\n",
+    "show(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot by bands\n",
+    "\n",
+    "Bands are plotted along the x-axis. Series are labeled by values of a feature property. Reduction of the region defined by the geometry of respective series features are plotted along the y-axis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from bokeh.plotting import figure, show\n",
+    "import numpy as np\n",
+    "\n",
+    "# Data for the chart\n",
+    "features = ['b1', 'b2', 'b3']\n",
+    "p1_values = [0.5, 2.5, 4.5]\n",
+    "p2_values = [1.5, 3.5, 5.5]\n",
+    "p3_values = [2.5, 4.0, 6.5]\n",
+    "\n",
+    "# Set the width of the bars\n",
+    "bar_width = 0.25\n",
+    "index = np.arange(len(features))\n",
+    "offset = 0.02\n",
+    "\n",
+    "# Create the plot\n",
+    "fig = figure(width=800, height=400)\n",
+    "\n",
+    "# Plotting the bars\n",
+    "rects1 = fig.vbar(x=index, top=p1_values, width=bar_width, legend_label='r1', color='#1d6b99')\n",
+    "rects2 = fig.vbar(x=index + (bar_width + offset), top=p2_values, width=bar_width, legend_label='r2', color='#cf513e')\n",
+    "rects3 = fig.vbar(x=index + 2 * (bar_width + offset), top=p3_values, width=bar_width, legend_label='r3', color='#f0af07')\n",
+    "\n",
+    "# Add labels, title, and custom x-axis tick labels\n",
+    "fig.yaxis.axis_label = \"Series reduction value\"\n",
+    "fig.xaxis.axis_label = \"band names\"\n",
+    "fig.outline_line_color = None\n",
+    "fig.legend.title = \"Regions by feature property value\"\n",
+    "fig.legend.location = \"top_left\"\n",
+    "fig.xaxis.ticker = index + (bar_width + offset)\n",
+    "fig.xaxis.major_label_overrides = dict(zip(index + (bar_width + offset), features))\n",
+    "fig.xgrid.grid_line_color = None\n",
+    "fig.legend.orientation = \"horizontal\"\n",
+    "\n",
+    "# Show the plot\n",
+    "show(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Colmun chart \n",
+    "\n",
+    "This chart shows total average precipitation per month for three ecoregions. The results are derived from the region reduction of an image where each band is a grid of average total precipitation for a given month. Bands are plotted along the x-axis and regions define the series."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = figure(width=800, height=400)\n",
+    "\n",
+    "normClim.bokeh.plot_by_bands(\n",
+    "    type = \"bar\",\n",
+    "    regions = ecoregions,\n",
+    "    reducer = \"mean\",\n",
+    "    scale = 500,\n",
+    "    regionId = \"label\",\n",
+    "    bands = ['01_ppt', '02_ppt', '03_ppt', '04_ppt', '05_ppt', '06_ppt', '07_ppt', '08_ppt', '09_ppt', '10_ppt', '11_ppt', '12_ppt'],\n",
+    "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
+    "    colors = [\"#f0af07\", \"#0f8755\", \"#76b349\"],\n",
+    "    figure = fig\n",
+    ")\n",
+    "\n",
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Average Monthly Precipitation by Ecoregion\"\n",
+    "fig.xaxis.axis_label = \"Month\"\n",
+    "fig.yaxis.axis_label = \"Precipitation (mm)\"\n",
+    "\n",
+    "show(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Line chart \n",
+    "\n",
+    "The previous column chart can be rendered as a line chart by changing the `type` input from \"bar\" to \"plot\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = figure(width=800, height=400)\n",
+    "\n",
+    "normClim.bokeh.plot_by_bands(\n",
+    "    type = \"plot\",\n",
+    "    regions = ecoregions,\n",
+    "    reducer = \"mean\",\n",
+    "    scale = 500,\n",
+    "    regionId = \"label\",\n",
+    "    bands = ['01_ppt', '02_ppt', '03_ppt', '04_ppt', '05_ppt', '06_ppt', '07_ppt', '08_ppt', '09_ppt', '10_ppt', '11_ppt', '12_ppt'],\n",
+    "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
+    "    colors = [\"#f0af07\", \"#0f8755\", \"#76b349\"],\n",
+    "    figure = fig\n",
+    ")\n",
+    "\n",
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Average Monthly Precipitation by Ecoregion\"\n",
+    "fig.xaxis.axis_label = \"Month\"\n",
+    "fig.yaxis.axis_label = \"Precipitation (mm)\"\n",
+    "\n",
+    "show(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Area chart \n",
+    "\n",
+    "The previous column chart can be rendered as a line chart by changing the `type` input from \"plot\" to \"fill_between\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = figure(width=800, height=400)\n",
+    "\n",
+    "fc = normClim.bokeh.plot_by_bands(\n",
+    "    type = \"fill_between\",\n",
+    "    regions = ecoregions,\n",
+    "    reducer = \"mean\",\n",
+    "    scale = 500,\n",
+    "    regionId = \"label\",\n",
+    "    bands = ['01_ppt', '02_ppt', '03_ppt', '04_ppt', '05_ppt', '06_ppt', '07_ppt', '08_ppt', '09_ppt', '10_ppt', '11_ppt', '12_ppt'],\n",
+    "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
+    "    colors = [\"#f0af07\", \"#0f8755\", \"#76b349\"],\n",
+    "    figure = fig\n",
+    ")\n",
+    "\n",
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Average Monthly Precipitation by Ecoregion\"\n",
+    "fig.xaxis.axis_label = \"Month\"\n",
+    "fig.yaxis.axis_label = \"Precipitation (mm)\"\n",
+    "\n",
+    "show(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pie chart \n",
+    "\n",
+    "Average monthly precipitation is displayed as a proportion of the average total annual precipitation for a forest ecoregion. Image bands representing monthly precipitation are subset from a climate normals dataset and reduced to the mean of pixels intersecting the ecoregion."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = figure(match_aspect=True)\n",
+    "\n",
+    "normClim.bokeh.plot_by_bands(\n",
+    "    type = \"pie\",\n",
+    "    regions = ecoregions.filter(ee.Filter.eq(\"label\", \"Forest\")),\n",
+    "    reducer = \"mean\",\n",
+    "    scale = 500,\n",
+    "    regionId = \"label\",\n",
+    "    bands = ['01_ppt', '02_ppt', '03_ppt', '04_ppt', '05_ppt', '06_ppt', '07_ppt', '08_ppt', '09_ppt', '10_ppt', '11_ppt', '12_ppt'],\n",
+    "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
+    "    colors = ['#604791', '#1d6b99', '#39a8a7', '#0f8755', '#76b349', '#f0af07', '#e37d05', '#cf513e', '#96356f', '#724173', '#9c4f97', '#696969'],\n",
+    "    figure = fig\n",
+    ")\n",
+    "\n",
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Average Monthly Precipitation in Forest\"\n",
+    "\n",
+    "show(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Donuts chart \n",
+    "\n",
+    "The previous chart can be represented as a donut by replacing the `type` parameter with `donut`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = figure(match_aspect=True)\n",
+    "\n",
+    "normClim.bokeh.plot_by_bands(\n",
+    "    type = \"donut\",\n",
+    "    regions = ecoregions.filter(ee.Filter.eq(\"label\", \"Forest\")),\n",
+    "    reducer = \"mean\",\n",
+    "    scale = 500,\n",
+    "    regionId = \"label\",\n",
+    "    bands = ['01_ppt', '02_ppt', '03_ppt', '04_ppt', '05_ppt', '06_ppt', '07_ppt', '08_ppt', '09_ppt', '10_ppt', '11_ppt', '12_ppt'],\n",
+    "    labels = [\"jan\", \"feb\", \"mar\", \"apr\", \"may\", \"jun\", \"jul\", \"aug\", \"sep\", \"oct\", \"nov\", \"dec\"],\n",
+    "    colors = ['#604791', '#1d6b99', '#39a8a7', '#0f8755', '#76b349', '#f0af07', '#e37d05', '#cf513e', '#96356f', '#724173', '#9c4f97', '#696969'],\n",
+    "    figure = fig\n",
+    ")\n",
+    "\n",
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Average Monthly Precipitation in Forest\"\n",
+    "\n",
+    "show(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## histogram plot \n",
+    "\n",
+    "A histogram of pixel values within a region surrounding Salt Lake City, Utah, USA are displayed for three MODIS surface reflectance bands. The histogram is plotted as a line chart, where x-axis values are pixel values and y-axis values are the frequency of pixels with the respective value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# custom image for this specific chart\n",
+    "modisSr = (\n",
+    "    ee.ImageCollection(\"MODIS/061/MOD09A1\")\n",
+    "    .filter(ee.Filter.date(\"2018-06-01\", \"2018-09-01\"))\n",
+    "    .select([\"sur_refl_b01\", \"sur_refl_b02\", \"sur_refl_b06\"])\n",
+    "    .mean()\n",
+    ")\n",
+    "histRegion = ee.Geometry.Rectangle([-112.60, 40.60, -111.18, 41.22])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = figure(width=800, height=400)\n",
+    "\n",
+    "# initialize the plot with the ecoregions data\n",
+    "modisSr.bokeh.plot_hist(\n",
+    "    bands = [\"sur_refl_b01\", \"sur_refl_b02\", \"sur_refl_b06\"],\n",
+    "    labels = [['Red', 'NIR', 'SWIR']],\n",
+    "    colors = [\"#cf513e\", \"#1d6b99\", \"#f0af07\"],\n",
+    "    figure = fig,\n",
+    "    bins = 100,\n",
+    "    scale = 500,\n",
+    "    region = histRegion,\n",
+    ")\n",
+    "\n",
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "fig.title.text = \"Modis SR Reflectance Histogram\"\n",
+    "fig.xaxis.axis_label = \"Reflectance (x1e4)\"\n",
+    "\n",
+    "show(fig)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ipygee",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/usage/plot/plot-imagecollection.ipynb
+++ b/docs/usage/plot/plot-imagecollection.ipynb
@@ -1,0 +1,709 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Plot ImageCollection\n",
+    "\n",
+    "The `geetools` extention contains a set of functions for rendering charts from the results of spatiotemporal reduction of images within an `ee.ImageCollection`. The choice of function dictates the arrangement of data in the chart, i.e., what defines x- and y-axis values and what defines the series. Use the following function descriptions and examples to determine the best function for your purpose."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import ee, geetools\n",
+    "from geetools.utils import initialize_documentation\n",
+    "\n",
+    "initialize_documentation()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![github](https://img.shields.io/badge/-see%20sources-white?logo=github&labelColor=555)](https://github.com/gee-community/geetools/blob/main/docs/usage/plot/plot-imagecollection.ipynb)\n",
+    "[![colab](https://img.shields.io/badge/-open%20in%20colab-blue?logo=googlecolab&labelColor=555)](https://colab.research.google.com/github/gee-community/geetools/blob/main/docs/usage/plot/plot-imagecollection.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set up environment\n",
+    "\n",
+    "Install all the required libs if necessary and perform the import satements upstream."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# uncomment if installation of libs is necessary\n",
+    "# !pip install earthengine-api geetools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from matplotlib import pyplot as plt\n",
+    "from datetime import datetime as dt\n",
+    "\n",
+    "import ee\n",
+    "import geetools #noqa: F401"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# uncomment if authetication to GEE is needed\n",
+    "# ee.Authenticate()\n",
+    "# ee.Intialize(project=\"<your_project>\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example data \n",
+    "\n",
+    "The following examples rely on a `ee.FeatureCollection` composed of three ecoregion features that define regions by which to reduce image data. The ImageCollection data loads the modis vegetation indicies and subset the 2010 2020 decade of images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Import the example feature collection and drop the data property.\n",
+    "ecoregions = (\n",
+    "    ee.FeatureCollection(\"projects/google/charts_feature_example\")\n",
+    "    .select([\"label\", \"value\", \"warm\"])\n",
+    ")\n",
+    "\n",
+    "\n",
+    "## Load MODIS vegetation indices data and subset a decade of images.\n",
+    "vegIndices = (\n",
+    "    ee.ImageCollection(\"MODIS/061/MOD13A1\")\n",
+    "    .filter(ee.Filter.date(\"2010-01-01\", \"2020-01-01\"))\n",
+    "    .select([\"NDVI\", \"EVI\"])\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot dates\n",
+    "\n",
+    "The `plot_dates*` methods will plot the values of the image collection using their dates as x-axis values."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### series by bands \n",
+    "\n",
+    "Image date is plotted along the x-axis according to the `dateProperty` property. Series are defined by image bands. Y-axis values are the reduction of images, by date, for a single region."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "# Sample data (replace these with your actual data)\n",
+    "dates = [\"date1\", \"date2\", \"date3\"]\n",
+    "b1 = [1, 2, 1]\n",
+    "b2 = [2, 3, 2]\n",
+    "b3 = [3, 4, 3]\n",
+    "\n",
+    "# Create the plot\n",
+    "ax.plot(dates, b1, label=\"b1\", color=\"#1d6b99\")\n",
+    "ax.plot(dates, b2, label=\"b2\", color=\"#cf513e\")\n",
+    "ax.plot(dates, b3, label=\"b3\", color=\"#f0af07\")\n",
+    "\n",
+    "# Add titles and labels\n",
+    "ax.set_title('Single-region spatial reduction')\n",
+    "ax.set_xlabel('Image date')\n",
+    "ax.set_ylabel('Spatial reduction')\n",
+    "\n",
+    "# Add a legend\n",
+    "ax.legend(loc='upper center', bbox_to_anchor=(0.85, 1.15), ncol=3, title='Band names')\n",
+    "\n",
+    "# set the grid display\n",
+    "ax.grid(axis=\"y\")\n",
+    "ax.set_ylim(0, 5)\n",
+    "ax.set_axisbelow(True)\n",
+    "ax.spines[\"top\"].set_visible(False)\n",
+    "ax.spines[\"right\"].set_visible(False)\n",
+    "\n",
+    "# Show the plot\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `plot_series_by_bands` to display an image time series for a given region; each image band is presented as a unique series. It is useful for comparing the time series of individual image bands. Here, a MODIS image collection with bands representing NDVI and EVI vegetation indices are plotted. The date of every image observation is included along the x-axis, while the mean reduction of pixels intersecting a forest ecoregion defines the y-axis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "region = ecoregions.filter(ee.Filter.eq(\"label\", \"Forest\"))\n",
+    "vegIndices.geetools.plot_dates_by_bands(\n",
+    "    region = region.geometry(),\n",
+    "    reducer = \"mean\",\n",
+    "    scale = 500,\n",
+    "    bands = [\"NDVI\", \"EVI\"],\n",
+    "    ax = ax,\n",
+    "    dateProperty = \"system:time_start\",\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "ax.set_ylabel(\"Vegetation indices (x1e4)\")\n",
+    "ax.set_title(\"Average Vegetation index Values by date in the Forest ecoregion\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{api}\n",
+    "- {docstring}`ee.ImageCollection.geetools.plot_dates_by_bands`\n",
+    "- {docstring}`ee.ImageCollection.geetools.datesByBands`\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot series by region\n",
+    "\n",
+    "Image date is plotted along the x-axis according to the `dateProperty` property. Series are defined by regions. Y-axis values are the reduction of images, by date, for a single image band."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "# Sample data (replace these with your actual data)\n",
+    "dates = [\"date1\", \"date2\", \"date3\"]\n",
+    "b1 = [1, 2, 1]\n",
+    "b2 = [2, 3, 2]\n",
+    "b3 = [3, 4, 3]\n",
+    "\n",
+    "# Create the plot\n",
+    "ax.plot(dates, b1, label=\"r1\", color=\"#1d6b99\")\n",
+    "ax.plot(dates, b2, label=\"r2\", color=\"#cf513e\")\n",
+    "ax.plot(dates, b3, label=\"r3\", color=\"#f0af07\")\n",
+    "\n",
+    "# Add titles and labels\n",
+    "ax.set_title(\"Single-band spatial reduction\")\n",
+    "ax.set_xlabel(\"Image date\")\n",
+    "ax.set_ylabel(\"Spatial reduction\")\n",
+    "\n",
+    "# Add a legend\n",
+    "ax.legend(loc='upper center', bbox_to_anchor=(0.85, 1.15), ncol=3, title='Regions')\n",
+    "\n",
+    "# set the grid display\n",
+    "ax.grid(axis=\"y\")\n",
+    "ax.set_ylim(0, 5)\n",
+    "ax.set_axisbelow(True)\n",
+    "ax.spines[\"top\"].set_visible(False)\n",
+    "ax.spines[\"right\"].set_visible(False)\n",
+    "\n",
+    "# Show the plot\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `plot_dates_by_regions` to display a single image band time series for multiple regions; each region is presented as a unique series. It is useful for comparing the time series of a single band among several regions. Here, a MODIS image collection representing an NDVI time series is plotted for three ecoregions. The date of every image observation is included along the x-axis, while mean reduction of pixels intersecting forest, desert, and grasslands ecoregions define y-axis series."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "region = ecoregions.filter(ee.Filter.eq(\"label\", \"Forest\"))\n",
+    "vegIndices.geetools.plot_dates_by_regions(\n",
+    "    band = \"NDVI\",\n",
+    "    regions = ecoregions,\n",
+    "    label = \"label\",\n",
+    "    reducer = \"mean\",\n",
+    "    scale = 500,\n",
+    "    ax = ax,\n",
+    "    dateProperty = \"system:time_start\",\n",
+    "    colors = ['#f0af07', '#0f8755', '#76b349']\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "ax.set_ylabel(\"Vegetation indices (x1e4)\")\n",
+    "ax.set_title(\"Average Vegetation index Values by date in the Forest ecoregion\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{api}\n",
+    "- {docstring}`ee.ImageCollection.geetools.plot_dates_by_regions`\n",
+    "- {docstring}`ee.ImageCollection.geetools.datesByRegions`\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## PLot DOY\n",
+    "\n",
+    "DOY stands for day of year. The `plot_doyseries*` methods will plot the values of the image collection using the day of year as x-axis values.\n",
+    "\n",
+    "Note that `.plot_doyseries*` functions take two reducers: one for region reduction (`regionReducer`) and another for intra-annual coincident day-of-year reduction (`yearReducer`). Examples in the following sections use `ee.Reducer.mean()` as the argument for both of these parameters."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot DOY by bands \n",
+    "\n",
+    "Image day-of-year is plotted along the x-axis according to the `dateProperty` property. Series are defined by image bands. Y-axis values are the reduction of image pixels in a given region, grouped by day-of-year."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "# Sample data (replace these with your actual data)\n",
+    "dates = [\"doy1\", \"doy2\", \"doy3\"]\n",
+    "b1 = [1, 2, 1]\n",
+    "b2 = [2, 3, 2]\n",
+    "b3 = [3, 4, 3]\n",
+    "\n",
+    "# Create the plot\n",
+    "ax.plot(dates, b1, label=\"b1\", color=\"#1d6b99\")\n",
+    "ax.plot(dates, b2, label=\"b2\", color=\"#cf513e\")\n",
+    "ax.plot(dates, b3, label=\"b3\", color=\"#f0af07\")\n",
+    "\n",
+    "# Add titles and labels\n",
+    "ax.set_title(\"Single-region spatiotemporal reduction\")\n",
+    "ax.set_xlabel(\"Image date\")\n",
+    "ax.set_ylabel(\"Reduced values\")\n",
+    "\n",
+    "# Add a legend\n",
+    "ax.legend(loc='upper center', bbox_to_anchor=(0.85, 1.15), ncol=3, title='Band names')\n",
+    "\n",
+    "# set the grid display\n",
+    "ax.grid(axis=\"y\")\n",
+    "ax.set_ylim(0, 5)\n",
+    "ax.set_axisbelow(True)\n",
+    "ax.spines[\"top\"].set_visible(False)\n",
+    "ax.spines[\"right\"].set_visible(False)\n",
+    "\n",
+    "# Show the plot\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `plot_doy_by_bands` to display a day-of-year time series for a given region; each image band is presented as a unique series. It is useful for reducing observations occurring on the same day-of-year, across multiple years, to compare e.g. average annual NDVI and EVI profiles from MODIS, as in this example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10,4))\n",
+    "\n",
+    "vegIndices.geetools.plot_doy_by_bands(\n",
+    "    region = ecoregions.filter(ee.Filter.eq(\"label\", \"Grassland\")).geometry(),\n",
+    "    spatialReducer = \"mean\",\n",
+    "    timeReducer = \"mean\",\n",
+    "    scale = 500,\n",
+    "    bands = [\"NDVI\", \"EVI\"],\n",
+    "    ax = ax,\n",
+    "    dateProperty = \"system:time_start\",\n",
+    "    colors = ['#e37d05', '#1d6b99']\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "ax.set_ylabel(\"Vegetation indices (x1e4)\")\n",
+    "ax.set_title(\"Average Vegetation index Values by doy in the Grassland ecoregion\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{api}\n",
+    "- {docstring}`ee.ImageCollection.geetools.plot_doy_by_bands`\n",
+    "- {docstring}`ee.ImageCollection.geetools.doyByBands`\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot doy by regions \n",
+    "\n",
+    "Image day-of-year is plotted along the x-axis according to the `dateProperty` property. Series are defined by regions. Y-axis values are the reduction of image pixels in a given region, grouped by day-of-year, for a selected image band.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "# Sample data (replace these with your actual data)\n",
+    "dates = [\"doy1\", \"doy2\", \"doy3\"]\n",
+    "b1 = [1, 2, 1]\n",
+    "b2 = [2, 3, 2]\n",
+    "b3 = [3, 4, 3]\n",
+    "\n",
+    "# Create the plot\n",
+    "ax.plot(dates, b1, label=\"r1\", color=\"#1d6b99\")\n",
+    "ax.plot(dates, b2, label=\"r2\", color=\"#cf513e\")\n",
+    "ax.plot(dates, b3, label=\"r3\", color=\"#f0af07\")\n",
+    "\n",
+    "# Add titles and labels\n",
+    "ax.set_title(\"Single-region spatiotemporal reduction\")\n",
+    "ax.set_xlabel(\"Image date\")\n",
+    "ax.set_ylabel(\"Reduced values\")\n",
+    "\n",
+    "# Add a legend\n",
+    "ax.legend(loc='upper center', bbox_to_anchor=(0.85, 1.15), ncol=3, title='regions')\n",
+    "\n",
+    "# set the grid display\n",
+    "ax.grid(axis=\"y\")\n",
+    "ax.set_ylim(0, 5)\n",
+    "ax.set_axisbelow(True)\n",
+    "ax.spines[\"top\"].set_visible(False)\n",
+    "ax.spines[\"right\"].set_visible(False)\n",
+    "\n",
+    "# Show the plot\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `plot_doy_by_regions` to display a single image band day-of-year time series for multiple regions, where each distinct region is presented as a unique series. It is useful for comparing annual single-band time series among regions. For instance, in this example, annual MODIS-derived NDVI profiles for forest, desert, and grassland ecoregions are plotted, providing a convenient comparison of NDVI response by region. Note that intra-annual observations occurring on the same day-of-year are reduced by their mean."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10,4))\n",
+    "\n",
+    "vegIndices.geetools.plot_doy_by_regions(\n",
+    "    regions = ecoregions,\n",
+    "    label = \"label\",\n",
+    "    spatialReducer = \"mean\",\n",
+    "    timeReducer = \"mean\",\n",
+    "    scale = 500,\n",
+    "    band = \"NDVI\",\n",
+    "    ax = ax,\n",
+    "    dateProperty = \"system:time_start\",\n",
+    "    colors = ['#f0af07', '#0f8755', '#76b349']\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "ax.set_ylabel(\"NDVI (x1e4)\")\n",
+    "ax.set_title(\"Average NDVI Values by doy in each ecoregion\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{api}\n",
+    "- {docstring}`ee.ImageCollection.geetools.plot_doy_by_regions`\n",
+    "- {docstring}`ee.ImageCollection.geetools.doyByRegions`\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### plot doy by year \n",
+    "\n",
+    "Image day-of-year is plotted along the x-axis according to the `dateProperty` property. Series are defined by years present in the ImageCollection. Y-axis values are the reduction of image pixels in a given region, grouped by day-of-year, for a selected image band."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "\n",
+    "# Sample data (replace these with your actual data)\n",
+    "dates = [\"doy1\", \"doy2\", \"doy3\"]\n",
+    "b1 = [1, 2, 1]\n",
+    "b2 = [2, 3, 2]\n",
+    "b3 = [3, 4, 3]\n",
+    "\n",
+    "# Create the plot\n",
+    "ax.plot(dates, b1, label=\"year1\", color=\"#1d6b99\")\n",
+    "ax.plot(dates, b2, label=\"year2\", color=\"#cf513e\")\n",
+    "ax.plot(dates, b3, label=\"year3\", color=\"#f0af07\")\n",
+    "\n",
+    "# Add titles and labels\n",
+    "ax.set_title(\"Single-region/band spatiotemporal reduction\")\n",
+    "ax.set_xlabel(\"Image date\")\n",
+    "ax.set_ylabel(\"Reduced values\")\n",
+    "\n",
+    "# Add a legend\n",
+    "ax.legend(loc='upper center', bbox_to_anchor=(0.85, 1.15), ncol=3, title='iage years')\n",
+    "\n",
+    "# set the grid display\n",
+    "ax.grid(axis=\"y\")\n",
+    "ax.set_ylim(0, 5)\n",
+    "ax.set_axisbelow(True)\n",
+    "ax.spines[\"top\"].set_visible(False)\n",
+    "ax.spines[\"right\"].set_visible(False)\n",
+    "\n",
+    "# Show the plot\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `plot_doy_by_years` to display a day-of-year time series for a given region and image band, where each distinct year in the image collection is presented as a unique series. It is useful for comparing annual time series among years. For instance, in this example, annual MODIS-derived NDVI profiles for a grassland ecoregion are plotted for years 2012 and 2019, providing convenient year-over-year interpretation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# reduce the regions to grassland\n",
+    "grassland = ecoregions.filter(ee.Filter.eq(\"label\", \"Grassland\"))\n",
+    "\n",
+    "# for plot speed and lisibility only keep 2 years (2010 and 2020) for the example\n",
+    "indices = vegIndices.filter(\n",
+    "        ee.Filter.Or(\n",
+    "            ee.Filter.date(\"2012-01-01\", \"2012-12-31\"),\n",
+    "            ee.Filter.date(\"2019-01-01\", \"2019-12-31\"),\n",
+    "        )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10,4))\n",
+    "\n",
+    "indices.geetools.plot_doy_by_years(\n",
+    "    band = \"NDVI\",\n",
+    "    region = grassland.geometry(),\n",
+    "    reducer = \"mean\",\n",
+    "    scale = 500,\n",
+    "    ax = ax,\n",
+    "    colors = ['#39a8a7', '#9c4f97']\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "ax.set_ylabel(\"NDVI (x1e4)\")\n",
+    "ax.set_title(\"Average NDVI Values by day of year for Grassland\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{api}\n",
+    "- {docstring}`ee.ImageCollection.geetools.plot_doy_by_years`\n",
+    "- {docstring}`ee.ImageCollection.geetools.doyByYears`\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### plot doy by seasons \n",
+    "\n",
+    "In case the observation you want to analyse are only meaningful on a subset of the year a variant of the previous method allows you to plot the data by season. The season is defined by the `seasonStart` and `seasonEnd` parameters, which are 2 numbers between 1 and 366 representing the start and end of the season. To set them, the user can use the {py:method}`ee.Date.getRelative` or {py:class}`time.struct_time` method to get the day of the year."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ee.Date(\"2022-06-01\").getRelative(\"day\", \"year\").getInfo()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt(2022, 6, 1).timetuple().tm_yday"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10,4))\n",
+    "\n",
+    "indices.geetools.plot_doy_by_seasons(\n",
+    "    band = \"NDVI\",\n",
+    "    region = grassland.geometry(),\n",
+    "    seasonStart = ee.Date(\"2022-04-15\").getRelative(\"day\", \"year\"),\n",
+    "    seasonEnd = ee.Date(\"2022-09-15\").getRelative(\"day\", \"year\"),\n",
+    "    reducer = \"mean\",\n",
+    "    scale = 500,\n",
+    "    ax = ax,\n",
+    "    colors = ['#39a8a7', '#9c4f97']\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "ax.set_ylabel(\"NDVI (x1e4)\")\n",
+    "ax.set_title(\"Average NDVI Values during growing season in Grassland\")\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{api}\n",
+    "- {docstring}`ee.ImageCollection.geetools.plot_doy_by_seasons`\n",
+    "- {docstring}`ee.ImageCollection.geetools.doyBySeasons`\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/usage/plot/plot-imagecollection.ipynb
+++ b/docs/usage/plot/plot-imagecollection.ipynb
@@ -29,8 +29,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![github](https://img.shields.io/badge/-see%20sources-white?logo=github&labelColor=555)](https://github.com/gee-community/geetools/blob/main/docs/usage/plot/plot-imagecollection.ipynb)\n",
-    "[![colab](https://img.shields.io/badge/-open%20in%20colab-blue?logo=googlecolab&labelColor=555)](https://colab.research.google.com/github/gee-community/geetools/blob/main/docs/usage/plot/plot-imagecollection.ipynb)"
+    "[![github](https://img.shields.io/badge/-see%20sources-white?logo=github&labelColor=555)](https://github.com/gee-community/ipygee/blob/main/docs/usage/plot/plot-imagecollection.ipynb)\n",
+    "[![colab](https://img.shields.io/badge/-open%20in%20colab-blue?logo=googlecolab&labelColor=555)](https://colab.research.google.com/github/gee-community/ipygee/blob/main/docs/usage/plot/plot-imagecollection.ipynb)"
    ]
   },
   {
@@ -62,7 +62,10 @@
     "from datetime import datetime as dt\n",
     "\n",
     "import ee\n",
-    "import geetools #noqa: F401"
+    "import ipygee #noqa: F401\n",
+    "from bokeh.io import output_notebook\n",
+    "\n",
+    "output_notebook()"
    ]
   },
   {
@@ -134,37 +137,37 @@
    },
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "from bokeh.plotting import figure, show\n",
+    "\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
     "# Sample data (replace these with your actual data)\n",
     "dates = [\"date1\", \"date2\", \"date3\"]\n",
+    "ticker_values = list(range(len(dates)))\n",
     "b1 = [1, 2, 1]\n",
     "b2 = [2, 3, 2]\n",
     "b3 = [3, 4, 3]\n",
     "\n",
     "# Create the plot\n",
-    "ax.plot(dates, b1, label=\"b1\", color=\"#1d6b99\")\n",
-    "ax.plot(dates, b2, label=\"b2\", color=\"#cf513e\")\n",
-    "ax.plot(dates, b3, label=\"b3\", color=\"#f0af07\")\n",
+    "fig.line(x=ticker_values, y=b1, legend_label=\"b1\", color=\"#1d6b99\")\n",
+    "fig.line(x=ticker_values, y=b2, legend_label=\"b2\", color=\"#cf513e\")\n",
+    "fig.line(x=ticker_values, y=b3, legend_label=\"b3\", color=\"#f0af07\")\n",
     "\n",
     "# Add titles and labels\n",
-    "ax.set_title('Single-region spatial reduction')\n",
-    "ax.set_xlabel('Image date')\n",
-    "ax.set_ylabel('Spatial reduction')\n",
+    "fig.title.text = \"Single-region spatial reduction\"\n",
+    "fig.xaxis.axis_label = \"Image date\"\n",
+    "fig.yaxis.axis_label = \"Spatial reduction\"\n",
+    "fig.y_range.start = 0\n",
+    "fig.y_range.end = 5\n",
+    "fig.legend.title = \"Band names\"\n",
+    "fig.legend.location = \"top_right\"\n",
+    "fig.xaxis.ticker = ticker_values\n",
+    "fig.xaxis.major_label_overrides = {i: date for i, date in enumerate(dates)}\n",
+    "fig.xgrid.grid_line_color = None\n",
+    "fig.legend.orientation = \"horizontal\"\n",
+    "fig.outline_line_color = None\n",
     "\n",
-    "# Add a legend\n",
-    "ax.legend(loc='upper center', bbox_to_anchor=(0.85, 1.15), ncol=3, title='Band names')\n",
-    "\n",
-    "# set the grid display\n",
-    "ax.grid(axis=\"y\")\n",
-    "ax.set_ylim(0, 5)\n",
-    "ax.set_axisbelow(True)\n",
-    "ax.spines[\"top\"].set_visible(False)\n",
-    "ax.spines[\"right\"].set_visible(False)\n",
-    "\n",
-    "# Show the plot\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
+    "show(fig)"
    ]
   },
   {
@@ -180,32 +183,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "fig = figure(width=800, height=400)\n",
+    "\n",
     "region = ecoregions.filter(ee.Filter.eq(\"label\", \"Forest\"))\n",
-    "vegIndices.geetools.plot_dates_by_bands(\n",
+    "col = vegIndices.bokeh.plot_dates_by_bands(\n",
     "    region = region.geometry(),\n",
     "    reducer = \"mean\",\n",
     "    scale = 500,\n",
     "    bands = [\"NDVI\", \"EVI\"],\n",
-    "    ax = ax,\n",
+    "    figure = fig,\n",
     "    dateProperty = \"system:time_start\",\n",
     ")\n",
     "\n",
-    "# once created the axes can be modified as needed using pure matplotlib functions\n",
-    "ax.set_ylabel(\"Vegetation indices (x1e4)\")\n",
-    "ax.set_title(\"Average Vegetation index Values by date in the Forest ecoregion\")\n",
+    "# once created the figure can be modified as needed using pure bokeh members\n",
+    "col.children[0].yaxis.axis_label = \"Vegetation indices (x1e4)\"\n",
+    "col.children[0].title.text = \"Average Vegetation index Values by date in the Forest ecoregion\"\n",
     "\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{api}\n",
-    "- {docstring}`ee.ImageCollection.geetools.plot_dates_by_bands`\n",
-    "- {docstring}`ee.ImageCollection.geetools.datesByBands`\n",
-    "```"
+    "show(col)"
    ]
   },
   {
@@ -227,37 +221,37 @@
    },
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "from bokeh.plotting import figure, show\n",
+    "\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
     "# Sample data (replace these with your actual data)\n",
     "dates = [\"date1\", \"date2\", \"date3\"]\n",
-    "b1 = [1, 2, 1]\n",
-    "b2 = [2, 3, 2]\n",
-    "b3 = [3, 4, 3]\n",
+    "ticker_values = list(range(len(dates)))\n",
+    "r1 = [1, 2, 1]\n",
+    "r2 = [2, 3, 2]\n",
+    "r3 = [3, 4, 3]\n",
     "\n",
     "# Create the plot\n",
-    "ax.plot(dates, b1, label=\"r1\", color=\"#1d6b99\")\n",
-    "ax.plot(dates, b2, label=\"r2\", color=\"#cf513e\")\n",
-    "ax.plot(dates, b3, label=\"r3\", color=\"#f0af07\")\n",
+    "fig.line(x=ticker_values, y=r1, legend_label=\"r1\", color=\"#1d6b99\")\n",
+    "fig.line(x=ticker_values, y=r2, legend_label=\"r2\", color=\"#cf513e\")\n",
+    "fig.line(x=ticker_values, y=r3, legend_label=\"r3\", color=\"#f0af07\")\n",
     "\n",
     "# Add titles and labels\n",
-    "ax.set_title(\"Single-band spatial reduction\")\n",
-    "ax.set_xlabel(\"Image date\")\n",
-    "ax.set_ylabel(\"Spatial reduction\")\n",
+    "fig.title.text = \"Single-band spatial reduction\"\n",
+    "fig.xaxis.axis_label = \"Image date\"\n",
+    "fig.yaxis.axis_label = \"Spatial reduction\"\n",
+    "fig.y_range.start = 0\n",
+    "fig.y_range.end = 5\n",
+    "fig.legend.title = \"Regions\"\n",
+    "fig.legend.location = \"top_right\"\n",
+    "fig.xaxis.ticker = ticker_values\n",
+    "fig.xaxis.major_label_overrides = {i: date for i, date in enumerate(dates)}\n",
+    "fig.xgrid.grid_line_color = None\n",
+    "fig.legend.orientation = \"horizontal\"\n",
+    "fig.outline_line_color = None\n",
     "\n",
-    "# Add a legend\n",
-    "ax.legend(loc='upper center', bbox_to_anchor=(0.85, 1.15), ncol=3, title='Regions')\n",
-    "\n",
-    "# set the grid display\n",
-    "ax.grid(axis=\"y\")\n",
-    "ax.set_ylim(0, 5)\n",
-    "ax.set_axisbelow(True)\n",
-    "ax.spines[\"top\"].set_visible(False)\n",
-    "ax.spines[\"right\"].set_visible(False)\n",
-    "\n",
-    "# Show the plot\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
+    "show(fig)"
    ]
   },
   {
@@ -273,34 +267,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "fig = figure(width=800, height=400)\n",
+    "\n",
     "region = ecoregions.filter(ee.Filter.eq(\"label\", \"Forest\"))\n",
-    "vegIndices.geetools.plot_dates_by_regions(\n",
+    "col = vegIndices.bokeh.plot_dates_by_regions(\n",
     "    band = \"NDVI\",\n",
     "    regions = ecoregions,\n",
     "    label = \"label\",\n",
     "    reducer = \"mean\",\n",
     "    scale = 500,\n",
-    "    ax = ax,\n",
+    "    figure = fig,\n",
     "    dateProperty = \"system:time_start\",\n",
     "    colors = ['#f0af07', '#0f8755', '#76b349']\n",
     ")\n",
     "\n",
     "# once created the axes can be modified as needed using pure matplotlib functions\n",
-    "ax.set_ylabel(\"Vegetation indices (x1e4)\")\n",
-    "ax.set_title(\"Average Vegetation index Values by date in the Forest ecoregion\")\n",
+    "col.children[0].yaxis.axis_label = \"Vegetation indices (x1e4)\"\n",
+    "col.children[0].title.text = \"Average Vegetation index Values by date in the Forest ecoregion\"\n",
     "\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{api}\n",
-    "- {docstring}`ee.ImageCollection.geetools.plot_dates_by_regions`\n",
-    "- {docstring}`ee.ImageCollection.geetools.datesByRegions`\n",
-    "```"
+    "show(col)"
    ]
   },
   {
@@ -333,37 +318,37 @@
    },
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "from bokeh.plotting import figure, show\n",
+    "\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
     "# Sample data (replace these with your actual data)\n",
     "dates = [\"doy1\", \"doy2\", \"doy3\"]\n",
+    "ticker_values = list(range(len(dates)))\n",
     "b1 = [1, 2, 1]\n",
     "b2 = [2, 3, 2]\n",
     "b3 = [3, 4, 3]\n",
     "\n",
     "# Create the plot\n",
-    "ax.plot(dates, b1, label=\"b1\", color=\"#1d6b99\")\n",
-    "ax.plot(dates, b2, label=\"b2\", color=\"#cf513e\")\n",
-    "ax.plot(dates, b3, label=\"b3\", color=\"#f0af07\")\n",
+    "fig.line(x=ticker_values, y=b1, legend_label=\"b1\", color=\"#1d6b99\")\n",
+    "fig.line(x=ticker_values, y=b2, legend_label=\"b2\", color=\"#cf513e\")\n",
+    "fig.line(x=ticker_values, y=b3, legend_label=\"b3\", color=\"#f0af07\")\n",
     "\n",
     "# Add titles and labels\n",
-    "ax.set_title(\"Single-region spatiotemporal reduction\")\n",
-    "ax.set_xlabel(\"Image date\")\n",
-    "ax.set_ylabel(\"Reduced values\")\n",
+    "fig.title.text = \"Single-band spatiotemporal reduction\"\n",
+    "fig.xaxis.axis_label = \"Image date\"\n",
+    "fig.yaxis.axis_label = \"Reduced values\"\n",
+    "fig.y_range.start = 0\n",
+    "fig.y_range.end = 5\n",
+    "fig.legend.title = \"Band names\"\n",
+    "fig.legend.location = \"top_right\"\n",
+    "fig.xaxis.ticker = ticker_values\n",
+    "fig.xaxis.major_label_overrides = {i: date for i, date in enumerate(dates)}\n",
+    "fig.xgrid.grid_line_color = None\n",
+    "fig.legend.orientation = \"horizontal\"\n",
+    "fig.outline_line_color = None\n",
     "\n",
-    "# Add a legend\n",
-    "ax.legend(loc='upper center', bbox_to_anchor=(0.85, 1.15), ncol=3, title='Band names')\n",
-    "\n",
-    "# set the grid display\n",
-    "ax.grid(axis=\"y\")\n",
-    "ax.set_ylim(0, 5)\n",
-    "ax.set_axisbelow(True)\n",
-    "ax.spines[\"top\"].set_visible(False)\n",
-    "ax.spines[\"right\"].set_visible(False)\n",
-    "\n",
-    "# Show the plot\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
+    "show(fig)"
    ]
   },
   {
@@ -379,34 +364,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10,4))\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
-    "vegIndices.geetools.plot_doy_by_bands(\n",
+    "vegIndices.bokeh.plot_doy_by_bands(\n",
     "    region = ecoregions.filter(ee.Filter.eq(\"label\", \"Grassland\")).geometry(),\n",
     "    spatialReducer = \"mean\",\n",
     "    timeReducer = \"mean\",\n",
     "    scale = 500,\n",
     "    bands = [\"NDVI\", \"EVI\"],\n",
-    "    ax = ax,\n",
+    "    figure = fig,\n",
     "    dateProperty = \"system:time_start\",\n",
     "    colors = ['#e37d05', '#1d6b99']\n",
     ")\n",
     "\n",
     "# once created the axes can be modified as needed using pure matplotlib functions\n",
-    "ax.set_ylabel(\"Vegetation indices (x1e4)\")\n",
-    "ax.set_title(\"Average Vegetation index Values by doy in the Grassland ecoregion\")\n",
+    "fig.yaxis.axis_label = \"Vegetation indices (x1e4)\"\n",
+    "fig.title.text = \"Average Vegetation index Values by doy in the Grassland ecoregion\"\n",
     "\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{api}\n",
-    "- {docstring}`ee.ImageCollection.geetools.plot_doy_by_bands`\n",
-    "- {docstring}`ee.ImageCollection.geetools.doyByBands`\n",
-    "```"
+    "show(fig)"
    ]
   },
   {
@@ -428,37 +403,37 @@
    },
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "from bokeh.plotting import figure, show\n",
+    "\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
     "# Sample data (replace these with your actual data)\n",
     "dates = [\"doy1\", \"doy2\", \"doy3\"]\n",
-    "b1 = [1, 2, 1]\n",
-    "b2 = [2, 3, 2]\n",
-    "b3 = [3, 4, 3]\n",
+    "ticker_values = list(range(len(dates)))\n",
+    "r1 = [1, 2, 1]\n",
+    "r2 = [2, 3, 2]\n",
+    "r3 = [3, 4, 3]\n",
     "\n",
     "# Create the plot\n",
-    "ax.plot(dates, b1, label=\"r1\", color=\"#1d6b99\")\n",
-    "ax.plot(dates, b2, label=\"r2\", color=\"#cf513e\")\n",
-    "ax.plot(dates, b3, label=\"r3\", color=\"#f0af07\")\n",
+    "fig.line(x=ticker_values, y=r1, legend_label=\"r1\", color=\"#1d6b99\")\n",
+    "fig.line(x=ticker_values, y=r2, legend_label=\"r2\", color=\"#cf513e\")\n",
+    "fig.line(x=ticker_values, y=r3, legend_label=\"r3\", color=\"#f0af07\")\n",
     "\n",
     "# Add titles and labels\n",
-    "ax.set_title(\"Single-region spatiotemporal reduction\")\n",
-    "ax.set_xlabel(\"Image date\")\n",
-    "ax.set_ylabel(\"Reduced values\")\n",
+    "fig.title.text = \"Single-region spatiotemporal reduction\"\n",
+    "fig.xaxis.axis_label = \"Image date\"\n",
+    "fig.yaxis.axis_label = \"Reduced values\"\n",
+    "fig.y_range.start = 0\n",
+    "fig.y_range.end = 5\n",
+    "fig.legend.title = \"Region names\"\n",
+    "fig.legend.location = \"top_right\"\n",
+    "fig.xaxis.ticker = ticker_values\n",
+    "fig.xaxis.major_label_overrides = {i: date for i, date in enumerate(dates)}\n",
+    "fig.xgrid.grid_line_color = None\n",
+    "fig.legend.orientation = \"horizontal\"\n",
+    "fig.outline_line_color = None\n",
     "\n",
-    "# Add a legend\n",
-    "ax.legend(loc='upper center', bbox_to_anchor=(0.85, 1.15), ncol=3, title='regions')\n",
-    "\n",
-    "# set the grid display\n",
-    "ax.grid(axis=\"y\")\n",
-    "ax.set_ylim(0, 5)\n",
-    "ax.set_axisbelow(True)\n",
-    "ax.spines[\"top\"].set_visible(False)\n",
-    "ax.spines[\"right\"].set_visible(False)\n",
-    "\n",
-    "# Show the plot\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
+    "show(fig)"
    ]
   },
   {
@@ -474,94 +449,38 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10,4))\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
-    "vegIndices.geetools.plot_doy_by_regions(\n",
+    "vegIndices.bokeh.plot_doy_by_regions(\n",
     "    regions = ecoregions,\n",
     "    label = \"label\",\n",
     "    spatialReducer = \"mean\",\n",
     "    timeReducer = \"mean\",\n",
     "    scale = 500,\n",
     "    band = \"NDVI\",\n",
-    "    ax = ax,\n",
+    "    figure = fig,\n",
     "    dateProperty = \"system:time_start\",\n",
     "    colors = ['#f0af07', '#0f8755', '#76b349']\n",
     ")\n",
     "\n",
     "# once created the axes can be modified as needed using pure matplotlib functions\n",
-    "ax.set_ylabel(\"NDVI (x1e4)\")\n",
-    "ax.set_title(\"Average NDVI Values by doy in each ecoregion\")\n",
+    "fig.yaxis.axis_label = \"NDVI (x1e4)\"\n",
+    "fig.title.text = \"Average NDVI Values by doy in each ecoregion\"\n",
     "\n",
-    "plt.show()"
+    "show(fig)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{api}\n",
-    "- {docstring}`ee.ImageCollection.geetools.plot_doy_by_regions`\n",
-    "- {docstring}`ee.ImageCollection.geetools.doyByRegions`\n",
+    "### plot doy by seasons \n",
+    "\n",
+    "In case the observation you want to analyse are only meaningful on a subset of the year a variant of the previous method allows you to plot the data by season. The season is defined by the `seasonStart` and `seasonEnd` parameters, which are 2 numbers between 1 and 366 representing the start and end of the season. To set them, the user can use the {py:method}`ee.Date.getRelative` or {py:class}`time.struct_time` method to get the day of the year. \n",
+    "\n",
+    "```{note} \n",
+    "The default season is a year (1, 366).\n",
     "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### plot doy by year \n",
-    "\n",
-    "Image day-of-year is plotted along the x-axis according to the `dateProperty` property. Series are defined by years present in the ImageCollection. Y-axis values are the reduction of image pixels in a given region, grouped by day-of-year, for a selected image band."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "remove-input"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "fig, ax = plt.subplots(figsize=(10, 4))\n",
-    "\n",
-    "# Sample data (replace these with your actual data)\n",
-    "dates = [\"doy1\", \"doy2\", \"doy3\"]\n",
-    "b1 = [1, 2, 1]\n",
-    "b2 = [2, 3, 2]\n",
-    "b3 = [3, 4, 3]\n",
-    "\n",
-    "# Create the plot\n",
-    "ax.plot(dates, b1, label=\"year1\", color=\"#1d6b99\")\n",
-    "ax.plot(dates, b2, label=\"year2\", color=\"#cf513e\")\n",
-    "ax.plot(dates, b3, label=\"year3\", color=\"#f0af07\")\n",
-    "\n",
-    "# Add titles and labels\n",
-    "ax.set_title(\"Single-region/band spatiotemporal reduction\")\n",
-    "ax.set_xlabel(\"Image date\")\n",
-    "ax.set_ylabel(\"Reduced values\")\n",
-    "\n",
-    "# Add a legend\n",
-    "ax.legend(loc='upper center', bbox_to_anchor=(0.85, 1.15), ncol=3, title='iage years')\n",
-    "\n",
-    "# set the grid display\n",
-    "ax.grid(axis=\"y\")\n",
-    "ax.set_ylim(0, 5)\n",
-    "ax.set_axisbelow(True)\n",
-    "ax.spines[\"top\"].set_visible(False)\n",
-    "ax.spines[\"right\"].set_visible(False)\n",
-    "\n",
-    "# Show the plot\n",
-    "plt.tight_layout()\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Use `plot_doy_by_years` to display a day-of-year time series for a given region and image band, where each distinct year in the image collection is presented as a unique series. It is useful for comparing annual time series among years. For instance, in this example, annual MODIS-derived NDVI profiles for a grassland ecoregion are plotted for years 2012 and 2019, providing convenient year-over-year interpretation."
    ]
   },
   {
@@ -588,106 +507,61 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(10,4))\n",
+    "fig = figure(width=800, height=400)\n",
     "\n",
-    "indices.geetools.plot_doy_by_years(\n",
-    "    band = \"NDVI\",\n",
-    "    region = grassland.geometry(),\n",
-    "    reducer = \"mean\",\n",
-    "    scale = 500,\n",
-    "    ax = ax,\n",
-    "    colors = ['#39a8a7', '#9c4f97']\n",
-    ")\n",
-    "\n",
-    "# once created the axes can be modified as needed using pure matplotlib functions\n",
-    "ax.set_ylabel(\"NDVI (x1e4)\")\n",
-    "ax.set_title(\"Average NDVI Values by day of year for Grassland\")\n",
-    "\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{api}\n",
-    "- {docstring}`ee.ImageCollection.geetools.plot_doy_by_years`\n",
-    "- {docstring}`ee.ImageCollection.geetools.doyByYears`\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### plot doy by seasons \n",
-    "\n",
-    "In case the observation you want to analyse are only meaningful on a subset of the year a variant of the previous method allows you to plot the data by season. The season is defined by the `seasonStart` and `seasonEnd` parameters, which are 2 numbers between 1 and 366 representing the start and end of the season. To set them, the user can use the {py:method}`ee.Date.getRelative` or {py:class}`time.struct_time` method to get the day of the year."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ee.Date(\"2022-06-01\").getRelative(\"day\", \"year\").getInfo()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dt(2022, 6, 1).timetuple().tm_yday"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, ax = plt.subplots(figsize=(10,4))\n",
-    "\n",
-    "indices.geetools.plot_doy_by_seasons(\n",
+    "indices.bokeh.plot_doy_by_seasons(\n",
     "    band = \"NDVI\",\n",
     "    region = grassland.geometry(),\n",
     "    seasonStart = ee.Date(\"2022-04-15\").getRelative(\"day\", \"year\"),\n",
     "    seasonEnd = ee.Date(\"2022-09-15\").getRelative(\"day\", \"year\"),\n",
     "    reducer = \"mean\",\n",
     "    scale = 500,\n",
-    "    ax = ax,\n",
+    "    figure = fig,\n",
     "    colors = ['#39a8a7', '#9c4f97']\n",
     ")\n",
     "\n",
     "# once created the axes can be modified as needed using pure matplotlib functions\n",
-    "ax.set_ylabel(\"NDVI (x1e4)\")\n",
-    "ax.set_title(\"Average NDVI Values during growing season in Grassland\")\n",
+    "fig.yaxis.axis_label = \"NDVI (x1e4)\"\n",
+    "fig.title.text = \"Average NDVI Values during growing season in Grassland\"\n",
     "\n",
-    "plt.show()"
+    "show(fig)"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "```{api}\n",
-    "- {docstring}`ee.ImageCollection.geetools.plot_doy_by_seasons`\n",
-    "- {docstring}`ee.ImageCollection.geetools.doyBySeasons`\n",
-    "```"
+    "fig = figure(width=800, height=400)\n",
+    "\n",
+    "indices.bokeh.plot_doy_by_seasons(\n",
+    "    band = \"NDVI\",\n",
+    "    region = grassland.geometry(),\n",
+    "    reducer = \"mean\",\n",
+    "    scale = 500,\n",
+    "    figure = fig,\n",
+    "    colors = ['#39a8a7', '#9c4f97']\n",
+    ")\n",
+    "\n",
+    "# once created the axes can be modified as needed using pure matplotlib functions\n",
+    "fig.yaxis.axis_label = \"NDVI (x1e4)\"\n",
+    "fig.title.text = \"Average NDVI Values by years\"\n",
+    "\n",
+    "show(fig)"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "ipygee",
    "language": "python",
    "name": "python3"
   },
@@ -701,7 +575,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/docs/usage/plot/plot-imagecollection.ipynb
+++ b/docs/usage/plot/plot-imagecollection.ipynb
@@ -76,7 +76,7 @@
    "source": [
     "# uncomment if authetication to GEE is needed\n",
     "# ee.Authenticate()\n",
-    "# ee.Intialize(project=\"<your_project>\")"
+    "# ee.Initialize(project=\"<your_project>\")"
    ]
   },
   {

--- a/ipygee/__init__.py
+++ b/ipygee/__init__.py
@@ -5,7 +5,6 @@ __author__ = "Pierrick Rambaud"
 __email__ = "pierrick.rambaud49@gmail.com"
 
 # import in the main class the extensions built for the different GEE native classes
-from .ee_feature_collection import (
-    FeatureCollectionAccessor as FeatureCollectionAccessor,
-)
-from .ee_image import ImageAccessor as ImageAccessor
+from .ee_feature_collection import FeatureCollectionAccessor  # noqa: F401
+from .ee_image import ImageAccessor  # noqa: F401
+from .ee_image_collection import ImageCollectionAccessor  # noqa: F401

--- a/ipygee/__init__.py
+++ b/ipygee/__init__.py
@@ -5,4 +5,7 @@ __author__ = "Pierrick Rambaud"
 __email__ = "pierrick.rambaud49@gmail.com"
 
 # import in the main class the extensions built for the different GEE native classes
+from .ee_feature_collection import (
+    FeatureCollectionAccessor as FeatureCollectionAccessor,
+)
 from .ee_image import ImageAccessor as ImageAccessor

--- a/ipygee/__init__.py
+++ b/ipygee/__init__.py
@@ -3,3 +3,6 @@
 __version__ = "0.0.0"
 __author__ = "Pierrick Rambaud"
 __email__ = "pierrick.rambaud49@gmail.com"
+
+# import in the main class the extensions built for the different GEE native classes
+from .ee_image import ImageAccessor as ImageAccessor

--- a/ipygee/ee_feature_collection.py
+++ b/ipygee/ee_feature_collection.py
@@ -26,9 +26,9 @@ class FeatureCollectionAccessor:
         properties: list[str] | None = None,
         labels: list[str] | None = None,
         colors: list[str] | None = None,
-        figure: plotting.Figure | None = None,
+        figure: plotting.figure | None = None,
         **kwargs,
-    ) -> plotting.Figure:
+    ) -> plotting.figure:
         """Plot the values of a :py:class:`ee.FeatureCollection` by feature.
 
         Each feature property selected in properties will be plotted using the ``featureId`` as the x-axis.
@@ -46,12 +46,6 @@ class FeatureCollectionAccessor:
             colors: A list of colors to use for plotting the properties. If not provided, the default colors from the matplotlib library will be used.
             figure: The bokeh figure to plot the data on. If None, a new figure is created.
             kwargs: Additional arguments from the ``pyplot`` type selected.
-
-        See Also:
-            - :docstring:`ee.FeatureCollection.geetools.byFeatures`
-            - :docstring:`ee.FeatureCollection.geetools.plot_by_properties`
-            - :docstring:`ee.FeatureCollection.geetools.plot_hist`
-            - :docstring:`ee.FeatureCollection.geetools.plot`
 
         Examples:
             .. jupyter-execute::
@@ -156,10 +150,10 @@ class FeatureCollectionAccessor:
         self,
         property: str | ee.String,
         label: str = "",
-        figure: plotting.Figure | None = None,
+        figure: plotting.figure | None = None,
         color: str | None = None,
         **kwargs,
-    ) -> plotting.Figure:
+    ) -> plotting.figure:
         """Plot the histogram of a specific property.
 
         Warning:

--- a/ipygee/ee_feature_collection.py
+++ b/ipygee/ee_feature_collection.py
@@ -1,0 +1,222 @@
+"""Toolbox for the :py:class:`ee.FeatureCollection` class."""
+from __future__ import annotations
+
+import ee
+import geetools  # noqa: F401
+import numpy as np
+from bokeh import plotting
+from geetools.accessors import register_class_accessor
+from matplotlib import pyplot as plt
+
+from .plotting import plot_data
+
+
+@register_class_accessor(ee.FeatureCollection, "bokeh")
+class FeatureCollectionAccessor:
+    """Toolbox for the :py:class:`ee.FeatureCollection` class."""
+
+    def __init__(self, obj: ee.FeatureCollection):
+        """Initialize the FeatureCollectionAccessor class."""
+        self._obj = obj
+
+    def plot_by_features(
+        self,
+        type: str = "bar",
+        featureId: str = "system:index",
+        properties: list[str] | None = None,
+        labels: list[str] | None = None,
+        colors: list[str] | None = None,
+        figure: plotting.Figure | None = None,
+        **kwargs,
+    ) -> plotting.Figure:
+        """Plot the values of a :py:class:`ee.FeatureCollection` by feature.
+
+        Each feature property selected in properties will be plotted using the ``featureId`` as the x-axis.
+        If no ``properties`` are provided, all properties will be plotted.
+        If no ``featureId`` is provided, the ``"system:index"`` property will be used.
+
+        Warning:
+            This function is a client-side function.
+
+        Args:
+            type: The type of plot to use. Defaults to ``"bar"``. can be any type of plot from the python lib ``matplotlib.pyplot``. If the one you need is missing open an issue!
+            featureId: The property to use as the x-axis (name the features). Defaults to ``"system:index"``.
+            properties: A list of properties to plot. Defaults to all properties.
+            labels: A list of labels to use for plotting the properties. If not provided, the default labels will be used. It needs to match the properties' length.
+            colors: A list of colors to use for plotting the properties. If not provided, the default colors from the matplotlib library will be used.
+            figure: The bokeh figure to plot the data on. If None, a new figure is created.
+            kwargs: Additional arguments from the ``pyplot`` type selected.
+
+        See Also:
+            - :docstring:`ee.FeatureCollection.geetools.byFeatures`
+            - :docstring:`ee.FeatureCollection.geetools.plot_by_properties`
+            - :docstring:`ee.FeatureCollection.geetools.plot_hist`
+            - :docstring:`ee.FeatureCollection.geetools.plot`
+
+        Examples:
+            .. jupyter-execute::
+
+                import ee, geetools
+                from geetools.utils import initialize_documentation
+                from matplotlib import pyplot as plt
+
+                initialize_documentation()
+
+                # start a plot object from matplotlib library
+                fig, ax = plt.subplots(figsize=(10, 5))
+
+                # plot on this object the 10 first items of the FAO GAUL level 2 feature collection
+                # for each one of them (marked with it's "ADM0_NAME" property) we plot the value of the "ADM1_CODE" and "ADM2_CODE" properties
+                fc = ee.FeatureCollection("FAO/GAUL/2015/level2").limit(10)
+                fc.geetools.plot_by_features(featureId="ADM2_NAME", properties=["ADM1_CODE", "ADM2_CODE"], colors=["#61A0D4", "#D49461"], ax=ax)
+
+                # Modify the rotation of existing x-axis tick labels
+                for label in ax.get_xticklabels():
+                    label.set_rotation(45)
+        """
+        # Get the features and properties
+        props = (
+            ee.List(properties)
+            if properties is not None
+            else self._obj.first().propertyNames().getInfo()
+        )
+        props = props.remove(featureId)
+
+        # get the data from server
+        data = self._obj.geetools.byProperties(featureId, props, labels).getInfo()
+
+        # reorder the data according to the labels or properties set by the user
+        labels = labels if labels is not None else props.getInfo()
+        data = {k: data[k] for k in labels}
+
+        return plot_data(
+            type=type, data=data, label_name=featureId, colors=colors, figure=figure, **kwargs
+        )
+
+    def plot_by_properties(
+        self,
+        type: str = "bar",
+        featureId: str = "system:index",
+        properties: list[str] | ee.List | None = None,
+        labels: list[str] | None = None,
+        colors: list[str] | None = None,
+        figure: plotting.Feature | None = None,
+        **kwargs,
+    ) -> plotting.Feature:
+        """Plot the values of a :py:class:`ee.FeatureCollection` by property.
+
+        Each features will be represented by a color and each property will be a bar of the bar chart.
+
+        Warning:
+            This function is a client-side function.
+
+        Args:
+            type: The type of plot to use. Defaults to ``"bar"``. can be any type of plot from the python lib ``matplotlib.pyplot``. If the one you need is missing open an issue!
+            featureId: The property to use as the y-axis (name the features). Defaults to ``"system:index"``.
+            properties: A list of properties to plot. Defaults to all properties.
+            labels: A list of labels to use for plotting the properties. If not provided, the default labels will be used. It needs to match the properties' length.
+            colors: A list of colors to use for plotting the properties. If not provided, the default colors from the matplotlib library will be used.
+            figure: The bokeh figure to plot the data on. If None, a new figure is created.
+            kwargs: Additional arguments from the ``pyplot`` function.
+
+        Examples:
+            .. jupyter-execute::
+
+                import ee, ipygee
+                from geetools.utils import initialize_documentation
+                from matplotlib import pyplot as plt
+
+                initialize_documentation()
+
+                # start a plot object from matplotlib library
+                fig, ax = plt.subplots(figsize=(10, 5))
+
+                # plot on this object the 10 first items of the FAO GAUL level 2 feature collection
+                # for each one of them (marked with it's "ADM2_NAME" property) we plot the value of the "ADM1_CODE" property
+                fc = ee.FeatureCollection("FAO/GAUL/2015/level2").limit(10)
+                fc.bokeh.plot_by_properties(featureId="ADM2_NAME", properties=["ADM1_CODE"], ax=ax)
+        """
+        # Get the features and properties
+        fc = self._obj
+        props = ee.List(properties) if properties is not None else fc.first().propertyNames()
+        props = props.remove(featureId)
+
+        # get the data from server
+        data = self._obj.geetools.byFeatures(featureId, props, labels).getInfo()
+
+        # reorder the data according to the lapbes or properties set by the user
+        labels = labels if labels is not None else props.getInfo()
+        data = {f: {k: data[f][k] for k in labels} for f in data.keys()}
+
+        return plot_data(
+            type=type, data=data, label_name=featureId, colors=colors, figure=figure, **kwargs
+        )
+
+    def plot_hist(
+        self,
+        property: str | ee.String,
+        label: str = "",
+        figure: plotting.Figure | None = None,
+        color: str | None = None,
+        **kwargs,
+    ) -> plotting.Figure:
+        """Plot the histogram of a specific property.
+
+        Warning:
+            This function is a client-side function.
+
+        Args:
+            property: The property to display
+            label: The label to use for the property. If not provided, the property name will be used.
+            figure: The bokeh figure to plot the data on. If None, a new figure is created.
+            color: The color to use for the plot. If not provided, the default colors from the matplotlib library will be used.
+            **kwargs: Additional arguments from the :py:func:`matplotlib.pyplot.hist` function.
+
+        Examples:
+            .. jupyter-execute::
+
+                import ee, ipygee
+                from geetools.utils import initialize_documentation
+                from matplotlib import pyplot as plt
+
+                initialize_documentation()
+
+                # start a plot object from matplotlib library
+                fig, ax = plt.subplots(figsize=(10, 5))
+                ax.set_title('Histogram of Precipitation in July')
+                ax.set_xlabel('Precipitation (mm)')
+
+
+                # build the histogram of the precipitation band for the month of july in the PRISM dataset
+                normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm81m').toBands()
+                region = ee.Geometry.Rectangle(-123.41, 40.43, -116.38, 45.14)
+                climSamp = normClim.sample(region, 5000)
+                climSamp.ipygee.plot_hist("07_ppt", ax=ax, bins=20)
+
+                fig.show()
+        """
+        # gather the data from parameters
+        properties, labels = ee.List([property]), ee.List([label])
+
+        # get the data from the server
+        data = self._obj.geetools.byProperties(properties=properties, labels=labels).getInfo()
+
+        # create the graph objcet if not provided
+        figure = plotting.figure() if figure is None else figure
+
+        # gather the data from the data variable
+        labels = list(data.keys())
+        if len(labels) != 1:
+            raise ValueError("histogram chart can only be used with one property")
+
+        color = color or plt.get_cmap("tab10").colors[0]
+        y, x = np.histogram(list(data[labels[0]].values()), **kwargs)
+        figure.vbar(x=x, top=y, width=0.9, color=color)
+
+        # customize the layout of the axis
+        figure.xaxis.axis_label = labels[0]
+        figure.yaxis.axis_label = "frequency"
+        figure.xgrid.grid_line_color = None
+        figure.outline_line_color = None
+
+        return figure

--- a/ipygee/ee_image.py
+++ b/ipygee/ee_image.py
@@ -28,12 +28,12 @@ class ImageAccessor:
         regionId: str = "system:index",
         labels: list[str] | None = None,
         colors: list[str] | None = None,
-        figure: plotting.Figure | None = None,
+        figure: plotting.figure | None = None,
         scale: int = 10000,
         crs: str | None = None,
         crsTransform: list | None = None,
         tileScale: float = 1,
-    ) -> plotting.Figure:
+    ) -> plotting.figure:
         """Plot the reduced values for each region.
 
         Each region will be plotted using the ``regionId`` as x-axis label defaulting to "system:index" if not provided.
@@ -112,12 +112,12 @@ class ImageAccessor:
         regionId: str = "system:index",
         labels: list[str] | None = None,
         colors: list[str] | None = None,
-        figure: plotting.Figure | None = None,
+        figure: plotting.figure | None = None,
         scale: int = 10000,
         crs: str | None = None,
         crsTransform: list | None = None,
         tileScale: float = 1,
-    ) -> plotting.Figure:
+    ) -> plotting.figure:
         """Plot the reduced values for each band.
 
         Each band will be plotted using the ``labels`` as x-axis label defaulting to band names if not provided.
@@ -195,7 +195,7 @@ class ImageAccessor:
         labels: list[str] | None = None,
         colors: list[str] | None = None,
         precision: int = 2,
-        figure: plotting.Figure | None = None,
+        figure: plotting.figure | None = None,
         scale: int = 10000,
         crs: str | None = None,
         crsTransform: list | None = None,
@@ -203,7 +203,7 @@ class ImageAccessor:
         maxPixels: int = 10**7,
         tileScale: float = 1,
         **kwargs,
-    ) -> plotting.Figure:
+    ) -> plotting.figure:
         """Plot the histogram of the image bands.
 
         Parameters:

--- a/ipygee/ee_image.py
+++ b/ipygee/ee_image.py
@@ -1,0 +1,317 @@
+"""Toolbox for the :py:class:`ee.Image` class."""
+from __future__ import annotations
+
+import ee
+import geetools  # noqa: F401
+from bokeh import plotting
+from geetools.accessors import register_class_accessor
+from matplotlib import pyplot as plt
+from matplotlib.colors import to_hex
+
+from .plotting import plot_data
+
+
+@register_class_accessor(ee.Image, "bokeh")
+class ImageAccessor:
+    """Toolbox for the :py:class:`ee.Image` class."""
+
+    def __init__(self, obj: ee.Image):
+        """Initialize the Image class."""
+        self._obj = obj
+
+    def plot_by_regions(
+        self,
+        type: str,
+        regions: ee.FeatureCollection,
+        reducer: str | ee.Reducer = "mean",
+        bands: list[str] | None = None,
+        regionId: str = "system:index",
+        labels: list[str] | None = None,
+        colors: list[str] | None = None,
+        figure: plotting.Figure | None = None,
+        scale: int = 10000,
+        crs: str | None = None,
+        crsTransform: list | None = None,
+        tileScale: float = 1,
+    ) -> plotting.Figure:
+        """Plot the reduced values for each region.
+
+        Each region will be plotted using the ``regionId`` as x-axis label defaulting to "system:index" if not provided.
+        If no ``bands`` are provided, all bands will be plotted.
+        If no ``labels`` are provided, the band names will be used.
+
+        Warning:
+            This method is client-side.
+
+        Parameters:
+            type: The type of plot to use. Defaults to ``"bar"``. can be any type of plot from the python lib ``matplotlib.pyplot``. If the one you need is missing open an issue!
+            regions: The regions to compute the reducer in.
+            reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            bands: The bands to compute the reducer on. Default to all bands.
+            regionId: The property used to label region. Defaults to ``"system:index"``.
+            labels: The labels to use for the output dictionary. Default to the band names.
+            colors: The colors to use for the plot. Default to the default matplotlib colors.
+            figure: The bokeh figure to plot the data on. If None, a new figure is created.
+            scale: The scale to use for the computation. Default is 10000m.
+            crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
+            crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
+            tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
+
+
+        Returns:
+            The bokeh figure with the plot.
+
+        See Also:
+            - :docstring:`ee.Image.geetools.byRegions`
+            - :docstring:`ee.Image.geetools.byBands`
+            - :docstring:`ee.Image.geetools.plot_by_bands`
+            - :docstring:`ee.Image.geetools.plot_hist`
+
+        Examples:
+            .. code-block:: python
+
+                import ee, geetools
+
+                ee.Initialize()
+
+                ecoregions = ee.FeatureCollection("projects/google/charts_feature_example").select(["label", "value","warm"])
+                normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()
+
+                normClim.geetools.plot_by_regions(ecoregions, ee.Reducer.mean(), scale=10000)
+        """
+        # get the data from the server
+        data = self._obj.geetools.byBands(
+            regions=regions,
+            reducer=reducer,
+            bands=bands,
+            regionId=regionId,
+            labels=labels,
+            scale=scale,
+            crs=crs,
+            crsTransform=crsTransform,
+            tileScale=tileScale,
+        ).getInfo()
+
+        # get all the id values, they must be string so we are forced to cast them manually
+        # the default casting is broken from Python side: https://issuetracker.google.com/issues/329106322
+        features = regions.aggregate_array(regionId)
+        isString = lambda i: ee.Algorithms.ObjectType(i).compareTo("String").eq(0)  # noqa: E731
+        features = features.map(lambda i: ee.Algorithms.If(isString(i), i, ee.Number(i).format()))
+        features = features.getInfo()
+
+        # extract the labels from the parameters
+        eeBands = ee.List(bands) if bands is not None else self._obj.bandNames()
+        labels = labels if labels is not None else eeBands.getInfo()
+
+        # reorder the data according to the labels id set by the user
+        data = {b: {f: data[b][f] for f in features} for b in labels}
+
+        ax = plot_data(type=type, data=data, label_name=regionId, colors=colors, figure=figure)
+
+        return ax
+
+    def plot_by_bands(
+        self,
+        type: str,
+        regions: ee.FeatureCollection,
+        reducer: str | ee.Reducer = "mean",
+        bands: list[str] | None = None,
+        regionId: str = "system:index",
+        labels: list[str] | None = None,
+        colors: list[str] | None = None,
+        figure: plotting.Figure | None = None,
+        scale: int = 10000,
+        crs: str | None = None,
+        crsTransform: list | None = None,
+        tileScale: float = 1,
+    ) -> plotting.Figure:
+        """Plot the reduced values for each band.
+
+        Each band will be plotted using the ``labels`` as x-axis label defaulting to band names if not provided.
+        If no ``bands`` are provided, all bands will be plotted.
+        If no ``regionId`` are provided, the ``"system:index"`` property will be used.
+
+
+        Warning:
+            This method is client-side.
+
+        Parameters:
+            type: The type of plot to use. Defaults to ``"bar"``. can be any type of plot from the python lib ``matplotlib.pyplot``. If the one you need is missing open an issue!
+            regions: The regions to compute the reducer in.
+            reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            bands: The bands to compute the reducer on. Default to all bands.
+            regionId: The property used to label region. Defaults to ``"system:index"``.
+            labels: The labels to use for the output dictionary. Default to the band names.
+            colors: The colors to use for the plot. Default to the default matplotlib colors.
+            figure: The bokeh figure to plot the data on. If None, a new figure is created.
+            scale: The scale to use for the computation. Default is 10000m.
+            crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
+            crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
+            tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
+
+        Returns:
+            The bokeh figure with the plot.
+
+        See Also:
+            - :docstring:`ee.Image.geetools.byRegions`
+            - :docstring:`ee.Image.geetools.byBands`
+            - :docstring:`ee.Image.geetools.plot_by_regions`
+            - :docstring:`ee.Image.geetools.plot_hist`
+
+        Examples:
+            .. code-block:: python
+
+                import ee, geetools
+
+                ee.Initialize()
+
+                ecoregions = ee.FeatureCollection("projects/google/charts_feature_example").select(["label", "value","warm"])
+                normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()
+
+                normClim.geetools.plot_by_bands(ecoregions, ee.Reducer.mean(), scale=10000)
+        """
+        # get the data from the server
+        data = self._obj.geetools.byRegions(
+            regions=regions,
+            reducer=reducer,
+            bands=bands,
+            regionId=regionId,
+            labels=labels,
+            scale=scale,
+            crs=crs,
+            crsTransform=crsTransform,
+            tileScale=tileScale,
+        ).getInfo()
+
+        # get all the id values, they must be string so we are forced to cast them manually
+        # the default casting is broken from Python side: https://issuetracker.google.com/issues/329106322
+        features = regions.aggregate_array(regionId)
+        isString = lambda i: ee.Algorithms.ObjectType(i).compareTo("String").eq(0)  # noqa: E731
+        features = features.map(lambda i: ee.Algorithms.If(isString(i), i, ee.Number(i).format()))
+        features = features.getInfo()
+
+        # extract the labels from the parameters
+        eeBands = ee.List(bands) if bands is not None else self._obj.bandNames()
+        labels = labels if labels is not None else eeBands.getInfo()
+
+        # reorder the data according to the labels id set by the user
+        data = {f: {b: data[f][b] for b in labels} for f in features}
+
+        ax = plot_data(type=type, data=data, label_name=regionId, colors=colors, figure=figure)
+
+        return ax
+
+    def plot_hist(
+        self,
+        bins: int = 30,
+        region: ee.Geometry | None = None,
+        bands: list[str] | None = None,
+        labels: list[str] | None = None,
+        colors: list[str] | None = None,
+        precision: int = 2,
+        figure: plotting.Figure | None = None,
+        scale: int = 10000,
+        crs: str | None = None,
+        crsTransform: list | None = None,
+        bestEffort: bool = False,
+        maxPixels: int = 10**7,
+        tileScale: float = 1,
+        **kwargs,
+    ) -> plotting.Figure:
+        """Plot the histogram of the image bands.
+
+        Parameters:
+            bins: The number of bins to use for the histogram. Default is 30.
+            region: The region to compute the histogram in. Default is the image geometry.
+            bands: The bands to plot the histogram for. Default to all bands.
+            labels: The labels to use for the output dictionary. Default to the band names.
+            colors: The colors to use for the plot. Default to the default matplotlib colors.
+            precision: The number of decimal to keep for the histogram bins values. Default is 2.
+            figure: The bokeh figure to plot the data on. If None, a new figure is created.
+            scale: The scale to use for the computation. Default is 10,000m.
+            crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
+            crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
+            bestEffort: If the polygon would contain too many pixels at the given scale, compute and use a larger scale which would allow the operation to succeed.
+            maxPixels: The maximum number of pixels to reduce. default to 10**7.
+            tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
+            **kwargs: Keyword arguments passed to the `matplotlib.fill_between() <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.fill_between.html>`_ function.
+
+        Returns:
+            The bokeh figure with the plot.
+
+        See Also:
+            - :docstring:`ee.Image.geetools.byRegions`
+            - :docstring:`ee.Image.geetools.byBands`
+            - :docstring:`ee.Image.geetools.plot_by_bands`
+            - :docstring:`ee.Image.geetools.plot_by_regions`
+
+
+        Examples:
+            .. code-block:: python
+
+                import ee, geetools
+
+                ee.Initialize()
+
+                normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()
+                normClim.geetools.plot_hist()
+        """
+        # extract the bands from the image
+        eeBands = ee.List(bands) if bands is not None else self._obj.bandNames()
+        eeLabels = ee.List(labels).flatten() if labels is not None else eeBands
+        new_labels: list[str] = eeLabels.getInfo()
+        new_colors: list[str] = colors if colors is not None else plt.get_cmap("tab10").colors
+
+        # retrieve the region from the parameters
+        region = region if region is not None else self._obj.geometry()
+
+        # extract the data from the server
+        image = self._obj.select(eeBands).rename(eeLabels).clip(region)
+
+        # set the common parameters of the 3 reducers
+        params = {
+            "geometry": region,
+            "scale": scale,
+            "crs": crs,
+            "crsTransform": crsTransform,
+            "bestEffort": bestEffort,
+            "maxPixels": maxPixels,
+            "tileScale": tileScale,
+        }
+
+        # compute the min and max values of the bands so w can scale the bins of the histogram
+        min = image.reduceRegion(**{"reducer": ee.Reducer.min(), **params})
+        min = min.values().reduce(ee.Reducer.min())
+
+        max = image.reduceRegion(**{"reducer": ee.Reducer.max(), **params})
+        max = max.values().reduce(ee.Reducer.max())
+
+        # compute the histogram. The result is a dictionary with each band as key and the histogram
+        # as values. The histograp is a list of [start of bin, value] pairs
+        reducer = ee.Reducer.fixedHistogram(min, max, bins)
+        raw_data = image.reduceRegion(**{"reducer": reducer, **params}).getInfo()
+
+        # massage raw data to reshape them as usable source for an Axes plot
+        # first extract the x coordinates of the plot as a list of bins borders
+        # every value is duplicated but the first one to create a scale like display.
+        # the values are treated the same way we simply drop the last duplication to get the same size.
+        p = 10**precision  # multiplier use to truncate the float values
+        x = [int(d[0] * p) / p for d in raw_data[new_labels[0]] for _ in range(2)][1:]
+        data = {lbl: [int(d[1]) for d in raw_data[lbl] for _ in range(2)][:-1] for lbl in new_labels}
+
+        # create the graph objcet if not provided
+        figure = plotting.figure() if figure is None else figure
+
+        # display the histogram as a fill_between plot to respect GEE lib design
+        for i, label in enumerate(new_labels):
+            y = data[label]
+            bottom = [0] * len(data[label])
+            color = to_hex(new_colors[i])
+            figure.varea(x=x, y1=bottom, y2=y, legend_label=label, color=color, alpha=0.2, **kwargs)
+            figure.line(x=x, y=y, legend_label=label, color=color)
+
+        # customize the layout of the axis
+        figure.yaxis.axis_label = "Count"
+        figure.xgrid.grid_line_color = None
+
+        return figure

--- a/ipygee/ee_image.py
+++ b/ipygee/ee_image.py
@@ -57,27 +57,20 @@ class ImageAccessor:
             crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
             tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
 
-
         Returns:
             The bokeh figure with the plot.
-
-        See Also:
-            - :docstring:`ee.Image.geetools.byRegions`
-            - :docstring:`ee.Image.geetools.byBands`
-            - :docstring:`ee.Image.geetools.plot_by_bands`
-            - :docstring:`ee.Image.geetools.plot_hist`
 
         Examples:
             .. code-block:: python
 
-                import ee, geetools
+                import ee, ipygee
 
                 ee.Initialize()
 
                 ecoregions = ee.FeatureCollection("projects/google/charts_feature_example").select(["label", "value","warm"])
                 normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()
 
-                normClim.geetools.plot_by_regions(ecoregions, ee.Reducer.mean(), scale=10000)
+                normClim.bokeh.plot_by_regions(ecoregions, ee.Reducer.mean(), scale=10000)
         """
         # get the data from the server
         data = self._obj.geetools.byBands(
@@ -131,7 +124,6 @@ class ImageAccessor:
         If no ``bands`` are provided, all bands will be plotted.
         If no ``regionId`` are provided, the ``"system:index"`` property will be used.
 
-
         Warning:
             This method is client-side.
 
@@ -150,25 +142,19 @@ class ImageAccessor:
             tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
 
         Returns:
-            The bokeh figure with the plot.
-
-        See Also:
-            - :docstring:`ee.Image.geetools.byRegions`
-            - :docstring:`ee.Image.geetools.byBands`
-            - :docstring:`ee.Image.geetools.plot_by_regions`
-            - :docstring:`ee.Image.geetools.plot_hist`
+            The bokeh figure with the plot
 
         Examples:
             .. code-block:: python
 
-                import ee, geetools
+                import ee, ipygee
 
                 ee.Initialize()
 
                 ecoregions = ee.FeatureCollection("projects/google/charts_feature_example").select(["label", "value","warm"])
                 normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()
 
-                normClim.geetools.plot_by_bands(ecoregions, ee.Reducer.mean(), scale=10000)
+                normClim.bokeh.plot_by_bands(ecoregions, ee.Reducer.mean(), scale=10000)
         """
         # get the data from the server
         data = self._obj.geetools.byRegions(
@@ -239,22 +225,15 @@ class ImageAccessor:
         Returns:
             The bokeh figure with the plot.
 
-        See Also:
-            - :docstring:`ee.Image.geetools.byRegions`
-            - :docstring:`ee.Image.geetools.byBands`
-            - :docstring:`ee.Image.geetools.plot_by_bands`
-            - :docstring:`ee.Image.geetools.plot_by_regions`
-
-
         Examples:
             .. code-block:: python
 
-                import ee, geetools
+                import ee, ipygee
 
                 ee.Initialize()
 
                 normClim = ee.ImageCollection('OREGONSTATE/PRISM/Norm91m').toBands()
-                normClim.geetools.plot_hist()
+                normClim.bokeh.plot_hist()
         """
         # extract the bands from the image
         eeBands = ee.List(bands) if bands is not None else self._obj.bandNames()
@@ -313,5 +292,6 @@ class ImageAccessor:
         # customize the layout of the axis
         figure.yaxis.axis_label = "Count"
         figure.xgrid.grid_line_color = None
+        figure.outline_line_color = None
 
         return figure

--- a/ipygee/ee_image_collection.py
+++ b/ipygee/ee_image_collection.py
@@ -1,0 +1,448 @@
+"""Toolbox for the :py:class:`ee.ImageCollection` class."""
+from __future__ import annotations
+
+from datetime import datetime as dt
+
+import ee
+import geetools  # noqa: F401
+from bokeh import plotting
+from geetools.accessors import register_class_accessor
+
+from .plotting import plot_data
+
+PY_DATE_FORMAT = "%Y-%m-%dT%H-%M-%S"
+"The python format to use to parse dates coming from GEE."
+
+EE_DATE_FORMAT = "YYYY-MM-dd'T'HH-mm-ss"
+"The javascript format to use to burn date object in GEE."
+
+
+@register_class_accessor(ee.ImageCollection, "bokeh")
+class ImageCollectionAccessor:
+    """Toolbox for the :py:class:`ee.ImageCollection` class."""
+
+    def __init__(self, obj: ee.ImageCollection):
+        """Initialize the ImageCollectionAccessor class."""
+        self._obj = obj
+
+    def plot_dates_by_bands(
+        self,
+        region: ee.Geometry,
+        reducer: str | ee.Reducer = "mean",
+        dateProperty: str = "system:time_start",
+        bands: list[str] | None = None,
+        labels: list[str] | None = None,
+        colors: list[str] | None = None,
+        figure: plotting.figure | None = None,
+        scale: int = 10000,
+        crs: str | None = None,
+        crsTransform: list | None = None,
+        bestEffort: bool = False,
+        maxPixels: int | None = 10**7,
+        tileScale: float = 1,
+    ) -> plotting.figure:
+        """Plot the reduced data for each image in the collection by bands on a specific region.
+
+        This method is plotting the reduced data for each image in the collection by bands on a specific region.
+
+        Parameters:
+            region: The region to reduce the data on.
+            reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
+            bands: The bands to reduce. If empty, all bands are reduced.
+            labels: The labels to use for the bands. If empty, the bands names are used.
+            colors: The colors to use for the bands. If empty, the default colors are used.
+            figure: The bokeh figure to plot the data on. If None, a new figure is created.
+            scale: The scale in meters to use for the reduction. default is 10000m
+            crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
+            crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
+            bestEffort: If the polygon would contain too many pixels at the given scale, compute and use a larger scale which would allow the operation to succeed.
+            maxPixels: The maximum number of pixels to reduce. Defaults to 1e7.
+            tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
+
+        Returns:
+            A bokeh figure with the reduced values for each band and each date.
+
+        Examples:
+            .. code-block:: python
+
+                import ee, geetools
+
+                ee.Initialize()
+
+                collection = (
+                    ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA")
+                    .filterBounds(ee.Geometry.Point(-122.262, 37.8719))
+                    .filterDate("2014-01-01", "2014-12-31")
+                )
+
+                region = ee.Geometry.Point(-122.262, 37.8719).buffer(10000)
+                collection.geetools.plot_dates_by_bands(region, "mean", 10000, "system:time_start")
+        """
+        # get the reduced data
+        raw_data = self._obj.geetools.datesByBands(
+            region=region,
+            reducer=reducer,
+            dateProperty=dateProperty,
+            bands=bands,
+            labels=labels,
+            scale=scale,
+            crs=crs,
+            crsTransform=crsTransform,
+            bestEffort=bestEffort,
+            maxPixels=maxPixels,
+            tileScale=tileScale,
+        ).getInfo()
+
+        # transform all the dates int datetime objects
+        def to_date(dict):
+            return {dt.strptime(d, PY_DATE_FORMAT): v for d, v in dict.items()}
+
+        data = {lbl: to_date(dict) for lbl, dict in raw_data.items()}
+
+        # create the plot
+        figure = plot_data(type="date", data=data, label_name="Date", colors=colors, figure=figure)
+
+        return figure
+
+    def plot_dates_by_regions(
+        self,
+        band: str,
+        regions: ee.FeatureCollection,
+        label: str = "system:index",
+        reducer: str | ee.Reducer = "mean",
+        dateProperty: str = "system:time_start",
+        colors: list[str] | None = None,
+        figure: plotting.figure | None = None,
+        scale: int = 10000,
+        crs: str | None = None,
+        crsTransform: list | None = None,
+        tileScale: float = 1,
+    ) -> plotting.figure:
+        """Plot the reduced data for each image in the collection by regions for a single band.
+
+        This method is plotting the reduced data for each image in the collection by regions for a single band.
+
+        Parameters:
+            band: The band to reduce.
+            regions: The regions to reduce the data on.
+            label: The property to use as label for each region. Default is ``"system:index"``.
+            reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
+            colors: The colors to use for the regions. If empty, the default colors are used.
+            figure: The bokeh figure to plot the data on. If None, a new figure is created.
+            scale: The scale in meters to use for the reduction. default is 10000m
+            crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
+            crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
+            tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
+
+        Returns:
+            A bokeh figure with the reduced values for each region and each date.
+
+        Examples:
+            .. code-block:: python
+
+                import ee, geetools
+
+                ee.Initialize()
+
+                collection = (
+                    ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA")
+                    .filterBounds(ee.Geometry.Point(-122.262, 37.8719))
+                    .filterDate("2014-01-01", "2014-12-31")
+                )
+
+                regions = ee.FeatureCollection([
+                    ee.Feature(ee.Geometry.Point(-122.262, 37.8719).buffer(10000), {"name": "region1"}),
+                    ee.Feature(ee.Geometry.Point(-122.262, 37.8719).buffer(20000), {"name": "region2"})
+                ])
+
+                collection.geetools.plot_dates_by_regions("B1", regions, "name", "mean", 10000, "system:time_start")
+        """
+        # get the reduced data
+        raw_data = self._obj.geetools.datesByRegions(
+            band=band,
+            regions=regions,
+            label=label,
+            reducer=reducer,
+            dateProperty=dateProperty,
+            scale=scale,
+            crs=crs,
+            crsTransform=crsTransform,
+            tileScale=tileScale,
+        ).getInfo()
+
+        # transform all the dates int datetime objects
+        def to_date(dict):
+            return {dt.strptime(d, PY_DATE_FORMAT): v for d, v in dict.items()}
+
+        data = {lbl: to_date(dict) for lbl, dict in raw_data.items()}
+
+        # create the plot
+        figure = plot_data("date", data, "Date", colors, figure)
+
+        return figure
+
+    def plot_doy_by_bands(
+        self,
+        region: ee.Geometry,
+        spatialReducer: str | ee.Reducer = "mean",
+        timeReducer: str | ee.Reducer = "mean",
+        dateProperty: str = "system:time_start",
+        bands: list[str] | None = None,
+        labels: list[str] | None = None,
+        colors: list[str] | None = None,
+        figure: plotting.figure | None = None,
+        scale: int = 10000,
+        crs: str | None = None,
+        crsTransform: list | None = None,
+        bestEffort: bool = False,
+        maxPixels: int | None = 10**7,
+        tileScale: float = 1,
+    ) -> plotting.figure:
+        """Plot the reduced data for each image in the collection by bands on a specific region.
+
+        This method is plotting the reduced data for each image in the collection by bands on a specific region.
+
+        Parameters:
+            region: The region to reduce the data on.
+            spatialReducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            timeReducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
+            bands: The bands to reduce. If empty, all bands are reduced.
+            labels: The labels to use for the bands. If empty, the bands names are used.
+            colors: The colors to use for the bands. If empty, the default colors are used.
+            figure: The bokeh figure to plot the data on. If None, a new figure is created.
+            scale: The scale in meters to use for the reduction. default is 10000m
+            crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
+            crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
+            bestEffort: If the polygon would contain too many pixels at the given scale, compute and use a larger scale which would allow the operation to succeed.
+            maxPixels: The maximum number of pixels to reduce. Defaults to 1e7.
+            tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
+
+        Returns:
+            A bokeh figure with the reduced values for each band and each day.
+
+        Examples:
+            .. code-block:: python
+
+                import ee, geetools
+
+                ee.Initialize()
+
+                collection = (
+                    ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA")
+                    .filterBounds(ee.Geometry.Point(-122.262, 37.8719))
+                    .filterDate("2014-01-01", "2014-12-31")
+                )
+
+                region = ee.Geometry.Point(-122.262, 37.8719).buffer(10000)
+                collection.geetools.plot_doy_by_bands(region, "mean", "mean", 10000, "system:time_start")
+        """
+        # get the reduced data
+        raw_data = self._obj.geetools.doyByBands(
+            region=region,
+            spatialReducer=spatialReducer,
+            timeReducer=timeReducer,
+            dateProperty=dateProperty,
+            bands=bands,
+            labels=labels,
+            scale=scale,
+            crs=crs,
+            crsTransform=crsTransform,
+            bestEffort=bestEffort,
+            maxPixels=maxPixels,
+            tileScale=tileScale,
+        ).getInfo()
+
+        # transform all the dates strings into int object and reorder the dictionary
+        def to_int(d):
+            return {int(k): v for k, v in d.items()}
+
+        data = {lbl: dict(sorted(to_int(raw_data[lbl]).items())) for lbl in raw_data}
+
+        # create the plot
+        figure = plot_data("doy", data, "Day of Year", colors, figure)
+
+        return figure
+
+    def plot_doy_by_regions(
+        self,
+        band: str,
+        regions: ee.FeatureCollection,
+        label: str = "system:index",
+        spatialReducer: str | ee.Reducer = "mean",
+        timeReducer: str | ee.Reducer = "mean",
+        dateProperty: str = "system:time_start",
+        colors: list[str] | None = None,
+        figure: plotting.figure | None = None,
+        scale: int = 10000,
+        crs: str | None = None,
+        crsTransform: list | None = None,
+        tileScale: float = 1,
+    ) -> plotting.figure:
+        """Plot the reduced data for each image in the collection by regions for a single band.
+
+        This method is plotting the reduced data for each image in the collection by regions for a single band.
+
+        Parameters:
+            band: The band to reduce.
+            regions: The regions to reduce the data on.
+            label: The property to use as label for each region. Default is ``"system:index"``.
+            spatialReducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            timeReducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
+            colors: The colors to use for the regions. If empty, the default colors are used.
+            figure: The bokeh figure to plot the data on. If None, a new figure is created.
+            scale: The scale in meters to use for the reduction. default is 10000m
+            crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
+            crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
+            tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
+
+        Returns:
+            A bokeh figure with the reduced values for each region and each day.
+
+        Examples:
+            .. code-block:: python
+
+                import ee, geetools
+
+                ee.Initialize()
+
+                collection = (
+                    ee.ImageCollection("LANDSAT/LC08/C01/T1_TOA")
+                    .filterBounds(ee.Geometry.Point(-122.262, 37.8719))
+                    .filterDate("2014-01-01", "2014-12-31")
+                )
+
+                regions = ee.FeatureCollection([
+                    ee.Feature(ee.Geometry.Point(-122.262, 37.8719).buffer(10000), {"name": "region1"}),
+                    ee.Feature(ee.Geometry.Point(-122.262, 37.8719).buffer(20000), {"name": "region2"})
+                ])
+
+                collection.geetools.plot_doy_by_regions("B1", regions, "name", "mean", "mean", 10000, "system:time_start")
+        """
+        # get the reduced data
+        raw_data = self._obj.geetools.doyByRegions(
+            band=band,
+            regions=regions,
+            label=label,
+            spatialReducer=spatialReducer,
+            timeReducer=timeReducer,
+            dateProperty=dateProperty,
+            scale=scale,
+            crs=crs,
+            crsTransform=crsTransform,
+            tileScale=tileScale,
+        ).getInfo()
+
+        # transform all the dates strings into int object and reorder the dictionary
+        def to_int(d):
+            return {int(k): v for k, v in d.items()}
+
+        data = {lbl: dict(sorted(to_int(raw_data[lbl]).items())) for lbl in raw_data}
+
+        # create the plot
+        figure = plot_data("doy", data, "Day of Year", colors, figure)
+
+        return figure
+
+    def plot_doy_by_seasons(
+        self,
+        band: str,
+        region: ee.Geometry,
+        seasonStart: int | ee.Number = 1,
+        seasonEnd: int | ee.Number = 366,
+        reducer: str | ee.Reducer = "mean",
+        dateProperty: str = "system:time_start",
+        colors: list[str] | None = None,
+        figure: plotting.figure | None = None,
+        scale: int = 10000,
+        crs: str | None = None,
+        crsTransform: list | None = None,
+        bestEffort: bool = False,
+        maxPixels: int | None = 10**7,
+        tileScale: float = 1,
+    ) -> plotting.figure:
+        """Plot the reduced data for each image in the collection by years for a single band.
+
+        This method is plotting the reduced data for each image in the collection by years for a single band.
+        To set the start and end of the season, use the :py:meth:`ee.Date.getRelative` or :py:class:`time.struct_time` method to get the day of the year.
+
+        Parameters:
+            band: The band to reduce.
+            region: The region to reduce the data on.
+            seasonStart: The day of the year that marks the start of the season.
+            seasonEnd: The day of the year that marks the end of the season.
+            reducer: The name of the reducer or a reducer object to use. Default is ``"mean"``.
+            dateProperty: The property to use as date for each image. Default is ``"system:time_start"``.
+            colors: The colors to use for the regions. If empty, the default colors are used.
+            figure: The bokeh figure to plot the data on. If None, a new figure is created.
+            scale: The scale in meters to use for the reduction. default is 10000m
+            crs: The projection to work in. If unspecified, the projection of the image's first band is used. If specified in addition to scale, rescaled to the specified scale.
+            crsTransform: The list of CRS transform values. This is a row-major ordering of the 3x2 transform matrix. This option is mutually exclusive with 'scale', and replaces any transform already set on the projection.
+            bestEffort: If the polygon would contain too many pixels at the given scale, compute and use a larger scale which would allow the operation to succeed.
+            maxPixels: The maximum number of pixels to reduce. Defaults to 1e7.
+            tileScale: A scaling factor between 0.1 and 16 used to adjust aggregation tile size; setting a larger tileScale (e.g., 2 or 4) uses smaller tiles and may enable computations that run out of memory with the default.
+
+        Returns:
+            A bokeh figure with the reduced values for each year and each day.
+
+        Examples:
+            .. jupyter-execute::
+
+                import ee, geetools
+                from geetools.utils import initialize_documentation
+
+                initialize_documentation()
+
+                collection = (
+                    ee.ImageCollection("LANDSAT/LC08/C02/T1_TOA")
+                    .filterBounds(ee.Geometry.Point(-122.262, 37.8719))
+                    .filter(ee.Filter.Or(
+                        ee.Filter.date("2022-01-01", "2022-12-31"),
+                        ee.Filter.date("2016-01-01", "2016-12-31"),
+                    ))
+                    .map(lambda i: ee.Image(i).addBands(
+                        ee.Image(i)
+                        .normalizedDifference(["B5", "B4"])
+                        .rename("NDVI")
+                    ))
+                )
+
+                collection.geetools.plot_doy_by_seasons(
+                    band = "NDVI",
+                    region = ee.Geometry.Point(-122.262, 37.8719).buffer(1000),
+                    seasonStart = ee.Date("2016-05-01").getRelative("day", "year"),
+                    seasonEnd = ee.Date("2016-10-31").getRelative("day", "year"),
+                    reducer = "mean",
+                    dateProperty = "system:time_start",
+                    scale = 10000
+                )
+        """
+        # get the reduced data
+        raw_data = self._obj.geetools.doyBySeasons(
+            band=band,
+            region=region,
+            seasonStart=seasonStart,
+            seasonEnd=seasonEnd,
+            reducer=reducer,
+            dateProperty=dateProperty,
+            scale=scale,
+            crs=crs,
+            crsTransform=crsTransform,
+            bestEffort=bestEffort,
+            maxPixels=maxPixels,
+            tileScale=tileScale,
+        ).getInfo()
+
+        # transform all the dates strings into int object and reorder the dictionary
+        def to_int(d):
+            return {int(k): v for k, v in d.items()}
+
+        data = {lbl: dict(sorted(to_int(raw_data[lbl]).items())) for lbl in raw_data}
+
+        # create the plot
+        figure = plot_data("doy", data, "Day of Year", colors, figure)
+
+        return figure

--- a/ipygee/plotting.py
+++ b/ipygee/plotting.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 from datetime import datetime as dt
 from math import pi
 
-import bokeh
 import numpy as np
+from bokeh import plotting
 from matplotlib import pyplot as plt
 
 
@@ -14,10 +14,10 @@ def plot_data(
     data: dict,
     label_name: str,
     colors: list[str] | None = None,
-    figure: bokeh.plotting.figure | None = None,
+    figure: plotting.figure | None = None,
     ax: plt.Axes | None = None,
     **kwargs,
-) -> bokeh.plotting.figure:
+) -> plotting.figure:
     """Plotting mechanism used in all the plotting functions.
 
     It binds the bokeh capabilities with the data aggregated by different axes.
@@ -42,8 +42,7 @@ def plot_data(
         kwargs: Additional arguments from the ``figure`` chart type selected.
     """
     # define the ax if not provided by the user
-    if figure is None:
-        figure = bokeh.plotting.figure(match_aspect=True)
+    figure = plotting.figure(match_aspect=True) if figure is None else figure
 
     # gather the data from parameters
     labels = list(data.keys())
@@ -69,8 +68,8 @@ def plot_data(
             figure.scatter(x=ticker_values, y=list(data[label].values()), **kwargs)
         figure.xaxis.ticker = ticker_values
         figure.xaxis.major_label_overrides = {i: p for i, p in enumerate(props)}
-        figure.yaxis.axis_name = props[0] if len(props) == 1 else "Properties values"
-        figure.xaxis.axis_name = f"Features (labeled by {label_name})"
+        figure.yaxis.axis_label = props[0] if len(props) == 1 else "Properties values"
+        figure.xaxis.axis_label = f"Features (labeled by {label_name})"
         figure.xgrid.grid_line_color = None
 
     elif type == "fill_between":

--- a/ipygee/plotting.py
+++ b/ipygee/plotting.py
@@ -1,0 +1,189 @@
+"""The extensive plotting function for bokhe binding."""
+from __future__ import annotations
+
+from datetime import datetime as dt
+from math import pi
+
+import bokeh
+import numpy as np
+from matplotlib import pyplot as plt
+
+
+def plot_data(
+    type: str,
+    data: dict,
+    label_name: str,
+    colors: list[str] | None = None,
+    figure: bokeh.plotting.figure | None = None,
+    ax: plt.Axes | None = None,
+    **kwargs,
+) -> bokeh.plotting.figure:
+    """Plotting mechanism used in all the plotting functions.
+
+    It binds the bokeh capabilities with the data aggregated by different axes.
+    the shape of the data should as follows:
+
+    .. code-block::
+
+        {
+            "label1": {"properties1": value1, "properties2": value2, ...}
+            "label2": {"properties1": value1, "properties2": value2, ...},
+            ...
+        }
+
+    Args:
+        type: The type of plot to use. can be any type of plot from the python lib `matplotlib.pyplot`. If the one you need is missing open an issue!
+        data: the data to use as inputs of the graph. Please follow the format specified in the documentation.
+        label_name: The name of the property that was used to generate the labels
+        property_names: The list of names that was used to name the values. They will be used to order the keys of the data dictionary.
+        colors: A list of colors to use for the plot. If not provided, the default colors from the matplotlib library will be used.
+        figure: The bokeh figure to use. If not provided, the plot will be sent to a new figure.
+        ax: The matplotlib axis to use. If not provided, the plot will be sent to a new axis.
+        kwargs: Additional arguments from the ``figure`` chart type selected.
+    """
+    # define the ax if not provided by the user
+    if figure is None:
+        figure = bokeh.plotting.figure(match_aspect=True)
+
+    # gather the data from parameters
+    labels = list(data.keys())
+    props = list(data[labels[0]].keys())
+    colors = colors if colors else plt.get_cmap("tab10").colors
+
+    # draw the chart based on the type
+    if type == "plot":
+        ticker_values = list(range(len(props)))
+        for i, label in enumerate(labels):
+            kwargs.update(color=colors[i], legend_label=label)
+            figure.line(x=ticker_values, y=list(data[label].values()), **kwargs)
+        figure.xaxis.ticker = ticker_values
+        figure.xaxis.major_label_overrides = {i: p for i, p in enumerate(props)}
+        figure.yaxis.axis_label = props[0] if len(props) == 1 else "Properties values"
+        figure.xaxis.axis_label = f"Features (labeled by {label_name})"
+        figure.xgrid.grid_line_color = None
+
+    elif type == "scatter":
+        ticker_values = list(range(len(props)))
+        for i, label in enumerate(labels):
+            kwargs.update(color=colors[i], legend_label=label)
+            figure.scatter(x=ticker_values, y=list(data[label].values()), **kwargs)
+        figure.xaxis.ticker = ticker_values
+        figure.xaxis.major_label_overrides = {i: p for i, p in enumerate(props)}
+        figure.yaxis.axis_name = props[0] if len(props) == 1 else "Properties values"
+        figure.xaxis.axis_name = f"Features (labeled by {label_name})"
+        figure.xgrid.grid_line_color = None
+
+    elif type == "fill_between":
+        ticker_values = list(range(len(props)))
+        for i, label in enumerate(labels):
+            values = list(data[label].values())
+            bottom = [0] * len(values)
+            kwargs.update(color=colors[i], legend_label=label)
+            figure.varea(x=ticker_values, y1=bottom, y2=values, alpha=0.2, **kwargs)
+            figure.line(x=ticker_values, y=values, **kwargs)
+        figure.xaxis.ticker = ticker_values
+        figure.xaxis.major_label_overrides = {i: p for i, p in enumerate(props)}
+        figure.yaxis.axis_label = props[0] if len(props) == 1 else "Properties values"
+        figure.xaxis.axis_label = f"Features (labeled by {label_name})"
+        figure.xgrid.grid_line_color = None
+
+    elif type == "bar":
+        ticker_values = list(range(len(props)))
+        data.update(props=ticker_values)
+
+        x = np.arange(len(props))
+        width = 1 / (len(labels) + 0.8)
+        margin = width / 10
+        ticks_value = x + width * len(labels) / 2
+        figure.xaxis.ticker = ticks_value
+        figure.xaxis.major_label_overrides = dict(zip(ticks_value, props))
+        for i, label in enumerate(labels):
+            values = list(data[label].values())
+            kwargs.update(legend_label=label, color=colors[i])
+            figure.vbar(x=x + width * i, top=values, width=width - margin, **kwargs)
+        figure.xgrid.grid_line_color = None
+
+    elif type == "barh":
+        y = np.arange(len(props))
+        height = 1 / (len(labels) + 0.8)
+        margin = height / 10
+        ticks_value = y + height * len(labels) / 2
+        figure.yaxis.ticker = ticks_value
+        figure.yaxis.major_label_overrides = dict(zip(ticks_value, props))
+        for i, label in enumerate(labels):
+            values = list(data[label].values())
+            kwargs.update(legend_label=label, color=colors[i])
+            figure.hbar(y=y + height * i, right=values, height=height - margin, **kwargs)
+        figure.ygrid.grid_line_color = None
+
+    elif type == "stacked":
+        for label in labels:
+            data[label] = [data[label][p] for p in props]
+        ticker_values = list(range(len(props)))
+        data.update(props=ticker_values)
+        kwargs.update(color=colors, legend_label=labels, width=0.9)
+        figure.vbar_stack(labels, x="props", source=data, **kwargs)
+        figure.xaxis.ticker = ticker_values
+        figure.xaxis.major_label_overrides = {i: p for i, p in enumerate(props)}
+        figure.xgrid.grid_line_color = None
+
+    elif type == "pie":
+        if len(labels) != 1:
+            raise ValueError("Pie chart can only be used with one property")
+        total = sum([data[labels[0]][p] for p in props])
+        kwargs.update(x=0, y=0, radius=1)
+        start_angle = 0
+        for i, p in enumerate(props):
+            kwargs.update(color=colors[i], legend_label=p)
+            end_angle = start_angle + data[labels[0]][p] / total * 2 * pi
+            figure.wedge(start_angle=start_angle, end_angle=end_angle, **kwargs)
+            start_angle = end_angle
+        figure.axis.visible = False
+        figure.x_range.start, figure.y_range.start = -1.5, -1.5
+        figure.x_range.end, figure.y_range.end = 1.5, 1.5
+        figure.grid.grid_line_color = None
+
+    elif type == "donut":
+        if len(labels) != 1:
+            raise ValueError("Pie chart can only be used with one property")
+        total = sum([data[labels[0]][p] for p in props])
+        kwargs.update(x=0, y=0, inner_radius=0.5, outer_radius=1)
+        start_angle = 0
+        for i, p in enumerate(props):
+            kwargs.update(color=colors[i], legend_label=p)
+            end_angle = start_angle + data[labels[0]][p] / total * 2 * pi
+            figure.annular_wedge(start_angle=start_angle, end_angle=end_angle, **kwargs)
+            start_angle = end_angle
+        figure.axis.visible = False
+        figure.x_range.start, figure.y_range.start = -1.5, -1.5
+        figure.x_range.end, figure.y_range.end = 1.5, 1.5
+        figure.grid.grid_line_color = None
+
+    elif type == "date":
+        for i, label in enumerate(labels):
+            kwargs["color"] = colors[i]
+            x, y = list(data[label].keys()), list(data[label].values())
+            ax.plot(x, y, label=label, **kwargs)
+        ax.set_xlabel("Date")
+
+    elif type == "doy":
+        xmin, xmax = 366, 0  # inverted initialization to get the first iteration values
+        for i, label in enumerate(labels):
+            kwargs["color"] = colors[i]
+            x, y = list(data[label].keys()), list(data[label].values())
+            ax.plot(x, y, label=label, **kwargs)
+            ax.set_xlabel("Day of year")
+            dates = [dt(2023, i + 1, 1) for i in range(12)]
+            idates = [int(d.strftime("%j")) - 1 for d in dates]
+            ndates = [d.strftime("%B")[:3] for d in dates]
+            ax.set_xticks(idates, ndates)
+            xmin, xmax = min(xmin, min(x)), max(xmax, max(x))
+        ax.set_xlim(xmin - 5, xmax + 5)
+
+    else:
+        raise ValueError(f"Type {type} is not (yet?) supported")
+
+    # final global layout edit
+    figure.outline_line_color = None
+
+    return figure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
   "natsort",
   "sidecar",
   "geemap",
+  "bokeh",
+  "jupyter_bokeh",
 ]
 
 [[project.authors]]


### PR DESCRIPTION
Everything is in the title I simply ported all the development made in geetools and matplotlib to the interactive world using bokeh. 
The graph can ba accessed the exact same way using the `bokeh` extention namespace. The only change is the name of the object when you define it before function call: In matplotlib it was an "ax" it's now a "figure" (to match bokeh API naming convention). 

Cool things that are brought to you via the interactivity of bokeh is to navigate within time series: 

![image](https://github.com/user-attachments/assets/d473d727-8928-433a-a98a-174c50020a1a)

It has the power to move from a static loading to a streaming system which would speed up the display in our use case but this is a first implementation. 

